### PR TITLE
feat(tests): Add automated testing infrastructure

### DIFF
--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -1,15 +1,45 @@
 /** @type {import('jest').Config} */
 module.exports = {
   moduleFileExtensions: ['js', 'json', 'ts'],
-  rootDir: 'src',
+  rootDir: '.',
   testRegex: '.*\\.spec\\.ts$',
   transform: {
-    '^.+\\.(t|j)s$': 'ts-jest',
+    '^.+\\.(t|j)s$': ['ts-jest', {
+      tsconfig: 'tsconfig.json',
+      useESM: false,
+    }],
   },
-  collectCoverageFrom: ['**/*.(t|j)s'],
-  coverageDirectory: '../coverage',
+  transformIgnorePatterns: [
+    'node_modules/(?!(@cs2-analytics)/)',
+  ],
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.module.ts',
+    '!src/**/*.dto.ts',
+    '!src/**/*.entity.ts',
+    '!src/**/*.interface.ts',
+    '!src/main.ts',
+    '!src/**/*.d.ts',
+  ],
+  coverageDirectory: './coverage',
+  coverageReporters: ['text', 'lcov', 'html'],
+  coverageThreshold: {
+    global: {
+      branches: 50,
+      functions: 50,
+      lines: 50,
+      statements: 50,
+    },
+  },
   testEnvironment: 'node',
   moduleNameMapper: {
-    '^src/(.*)$': '<rootDir>/$1',
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '^@cs2-analytics/db$': '<rootDir>/../../packages/db/src/index.ts',
+    '^@cs2-analytics/types$': '<rootDir>/../../packages/types/src/index.ts',
   },
+  setupFilesAfterEnv: ['<rootDir>/test/setup.ts'],
+  testTimeout: 30000,
+  verbose: true,
+  detectOpenHandles: true,
+  forceExit: true,
 };

--- a/apps/api/src/__tests__/health.controller.spec.ts
+++ b/apps/api/src/__tests__/health.controller.spec.ts
@@ -1,0 +1,204 @@
+/**
+ * Health Controller Tests
+ *
+ * Tests for the health check endpoints.
+ */
+
+// Mock dependencies before imports
+const mockPrismaService = {
+  $queryRaw: jest.fn().mockResolvedValue([{ '?column?': 1 }]),
+  $connect: jest.fn(),
+  $disconnect: jest.fn(),
+};
+
+const mockQueue = {
+  getJobCounts: jest.fn().mockResolvedValue({
+    waiting: 0,
+    active: 0,
+    failed: 0,
+    completed: 10,
+  }),
+};
+
+const mockParserService = {
+  checkHealth: jest.fn().mockResolvedValue(true),
+  getCircuitBreakerStatus: jest.fn().mockReturnValue({
+    state: 'CLOSED',
+    failures: 0,
+  }),
+};
+
+// Mock modules
+jest.mock('../common/prisma', () => ({
+  PrismaService: jest.fn().mockImplementation(() => mockPrismaService),
+}));
+
+jest.mock('../modules/demo/parser.service', () => ({
+  ParserService: jest.fn().mockImplementation(() => mockParserService),
+}));
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { HealthController } from '../health.controller';
+import { PrismaService } from '../common/prisma';
+import { ParserService } from '../modules/demo/parser.service';
+import { getQueueToken } from '@nestjs/bullmq';
+
+describe('HealthController', () => {
+  let controller: HealthController;
+
+  beforeEach(async () => {
+    // Reset all mocks
+    jest.clearAllMocks();
+    mockPrismaService.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);
+    mockQueue.getJobCounts.mockResolvedValue({
+      waiting: 0,
+      active: 0,
+      failed: 0,
+      completed: 10,
+    });
+    mockParserService.checkHealth.mockResolvedValue(true);
+    mockParserService.getCircuitBreakerStatus.mockReturnValue({
+      state: 'CLOSED',
+      failures: 0,
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HealthController],
+      providers: [
+        { provide: PrismaService, useValue: mockPrismaService },
+        { provide: getQueueToken('demo-parsing'), useValue: mockQueue },
+        { provide: ParserService, useValue: mockParserService },
+      ],
+    }).compile();
+
+    controller = module.get<HealthController>(HealthController);
+  });
+
+  describe('health', () => {
+    it('should return basic health status', () => {
+      const result = controller.health();
+
+      expect(result).toHaveProperty('status', 'ok');
+      expect(result).toHaveProperty('timestamp');
+      expect(new Date(result.timestamp)).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('ready', () => {
+    it('should return ready status when database is connected', async () => {
+      const result = await controller.ready();
+
+      expect(result).toHaveProperty('ready', true);
+      expect(result.checks).toHaveProperty('database', true);
+      expect(mockPrismaService.$queryRaw).toHaveBeenCalled();
+    });
+
+    it('should return not ready when database fails', async () => {
+      mockPrismaService.$queryRaw.mockRejectedValueOnce(new Error('Connection failed'));
+
+      const result = await controller.ready();
+
+      expect(result.checks.database).toBe(false);
+      expect(result.ready).toBe(false);
+    });
+
+    it('should check queue connection', async () => {
+      const result = await controller.ready();
+
+      expect(result.checks).toHaveProperty('queue', true);
+      expect(mockQueue.getJobCounts).toHaveBeenCalled();
+    });
+  });
+
+  describe('detailedHealth', () => {
+    it('should return detailed health with all components', async () => {
+      const result = await controller.detailedHealth();
+
+      expect(result).toHaveProperty('status');
+      expect(result).toHaveProperty('service', 'cs2-analytics-api');
+      expect(result).toHaveProperty('timestamp');
+      expect(result).toHaveProperty('uptime');
+      expect(result).toHaveProperty('version');
+      expect(result).toHaveProperty('checks');
+    });
+
+    it('should return healthy when all checks pass', async () => {
+      const result = await controller.detailedHealth();
+
+      expect(result.status).toBe('healthy');
+      expect(result.checks?.database.status).toBe('healthy');
+    });
+
+    it('should include database latency', async () => {
+      const result = await controller.detailedHealth();
+
+      expect(result.checks?.database).toHaveProperty('latency');
+      expect(typeof result.checks?.database.latency).toBe('number');
+    });
+
+    it('should return unhealthy when database fails', async () => {
+      mockPrismaService.$queryRaw.mockRejectedValueOnce(new Error('DB error'));
+
+      const result = await controller.detailedHealth();
+
+      expect(result.status).toBe('unhealthy');
+      expect(result.checks?.database.status).toBe('unhealthy');
+    });
+
+    it('should include queue job counts', async () => {
+      const result = await controller.detailedHealth();
+
+      expect(result.checks?.queue).toHaveProperty('jobs');
+      expect(result.checks?.queue.jobs).toEqual({
+        waiting: 0,
+        active: 0,
+        failed: 0,
+      });
+    });
+
+    it('should show degraded status when many jobs failed', async () => {
+      mockQueue.getJobCounts.mockResolvedValueOnce({
+        waiting: 0,
+        active: 0,
+        failed: 15,
+        completed: 100,
+      });
+
+      const result = await controller.detailedHealth();
+
+      expect(result.checks?.queue.status).toBe('degraded');
+    });
+
+    it('should include parser circuit breaker status', async () => {
+      const result = await controller.detailedHealth();
+
+      expect(result.checks?.parser).toHaveProperty('circuitBreaker');
+      expect(result.checks?.parser.circuitBreaker).toEqual({
+        state: 'CLOSED',
+        failures: 0,
+      });
+    });
+  });
+
+  describe('root', () => {
+    it('should return API info', () => {
+      const result = controller.root();
+
+      expect(result).toHaveProperty('name', 'CS2 Analytics API');
+      expect(result).toHaveProperty('version');
+      expect(result).toHaveProperty('description');
+      expect(result).toHaveProperty('documentation', '/docs');
+      expect(result).toHaveProperty('endpoints');
+    });
+
+    it('should list all available endpoints', () => {
+      const result = controller.root();
+
+      expect(result.endpoints).toHaveProperty('demos');
+      expect(result.endpoints).toHaveProperty('players');
+      expect(result.endpoints).toHaveProperty('rounds');
+      expect(result.endpoints).toHaveProperty('analysis');
+      expect(result.endpoints).toHaveProperty('health');
+    });
+  });
+});

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -1,0 +1,50 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
+import { AppModule } from '../src/app.module';
+
+describe('App (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication<NestFastifyApplication>(
+      new FastifyAdapter(),
+    );
+
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        transform: true,
+        forbidNonWhitelisted: true,
+      }),
+    );
+
+    await app.init();
+    await app.getHttpAdapter().getInstance().ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('Health Check', () => {
+    it('/health (GET) should return health status', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/health',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body).toHaveProperty('status');
+      expect(body.status).toBe('ok');
+    });
+  });
+});

--- a/apps/api/test/jest-e2e.json
+++ b/apps/api/test/jest-e2e.json
@@ -1,0 +1,17 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": "..",
+  "testEnvironment": "node",
+  "testRegex": ".e2e-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^@/(.*)$": "<rootDir>/src/$1"
+  },
+  "setupFilesAfterEnv": ["<rootDir>/test/setup.ts"],
+  "testTimeout": 60000,
+  "verbose": true,
+  "detectOpenHandles": true,
+  "forceExit": true
+}

--- a/apps/api/test/setup.ts
+++ b/apps/api/test/setup.ts
@@ -1,0 +1,27 @@
+/**
+ * Jest Test Setup
+ *
+ * Configures the test environment before running tests.
+ */
+
+// Increase timeout for async operations
+jest.setTimeout(30000);
+
+// Mock environment variables
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-jwt-secret';
+process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+process.env.REDIS_URL = 'redis://localhost:6379';
+
+// Suppress console logs during tests (optional)
+// global.console = {
+//   ...console,
+//   log: jest.fn(),
+//   debug: jest.fn(),
+//   info: jest.fn(),
+// };
+
+// Clean up after all tests
+afterAll(async () => {
+  // Add any global cleanup here
+});


### PR DESCRIPTION
## Summary
- Configure Jest with TypeScript support and ES module handling
- Add test setup file with mocked environment variables
- Create comprehensive health controller unit tests (13 tests passing)
- Add e2e test configuration for integration testing
- Set coverage thresholds at 50% for branches/functions/lines/statements

## Test Results
```
PASS src/__tests__/health.controller.spec.ts
  HealthController
    health
      ✓ should return basic health status
    ready
      ✓ should return ready status when database is connected
      ✓ should return not ready when database fails
      ✓ should check queue connection
    detailedHealth
      ✓ should return detailed health with all components
      ✓ should return healthy when all checks pass
      ✓ should include database latency
      ✓ should return unhealthy when database fails
      ✓ should include queue job counts
      ✓ should show degraded status when many jobs failed
      ✓ should include parser circuit breaker status
    root
      ✓ should return API info
      ✓ should list all available endpoints

Test Suites: 1 passed, 1 total
Tests:       13 passed, 13 total
```

## Files Added
- `apps/api/jest.config.js` - Jest configuration
- `apps/api/test/setup.ts` - Test environment setup
- `apps/api/src/__tests__/health.controller.spec.ts` - Health controller tests
- `apps/api/test/app.e2e-spec.ts` - E2E test structure
- `apps/api/test/jest-e2e.json` - E2E Jest configuration

## Test Plan
- [x] All 13 unit tests pass locally
- [ ] CI pipeline runs tests successfully
- [ ] Coverage meets 50% threshold

Closes #10