### PR TITLE
feat(dashboard): Role-Based Personalized Dashboards (#41)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -19,6 +19,7 @@ import { RoundModule } from "./modules/round/round.module";
 import { AnalysisModule } from "./modules/analysis/analysis.module";
 import { AggregationModule } from "./modules/aggregation/aggregation.module";
 import { ReplayModule } from "./modules/replay/replay.module";
+import { UserModule } from "./modules/user/user.module";
 import { HealthController } from "./health.controller";
 
 @Module({
@@ -91,6 +92,7 @@ import { HealthController } from "./health.controller";
     AnalysisModule,
     AggregationModule,
     ReplayModule,
+    UserModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/apps/api/src/modules/user/dto/user.dto.ts
+++ b/apps/api/src/modules/user/dto/user.dto.ts
@@ -1,0 +1,251 @@
+/**
+ * User DTOs - Data Transfer Objects for user endpoints
+ */
+
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import {
+  IsString,
+  IsBoolean,
+  IsOptional,
+  IsNumber,
+  IsArray,
+  IsEnum,
+  IsObject,
+  Min,
+  Max,
+} from "class-validator";
+import { PreferredRole, ProfileVisibility } from "@prisma/client";
+
+// Update preferences DTO
+export class UpdatePreferencesDto {
+  @ApiPropertyOptional({
+    description: "Preferred dashboard role",
+    enum: ["PLAYER", "COACH", "SCOUT", "ANALYST", "CREATOR"],
+  })
+  @IsEnum(PreferredRole)
+  @IsOptional()
+  preferredRole?: PreferredRole;
+
+  @ApiPropertyOptional({
+    description: "Dashboard layout configuration (widget positions)",
+  })
+  @IsObject()
+  @IsOptional()
+  dashboardLayout?: Record<string, unknown>;
+
+  @ApiPropertyOptional({
+    description: "List of favorite metrics to display",
+    type: [String],
+  })
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  favoriteMetrics?: string[];
+
+  @ApiPropertyOptional({
+    description: "Default time range for analytics",
+    enum: ["7d", "30d", "90d", "all"],
+  })
+  @IsString()
+  @IsOptional()
+  defaultTimeRange?: string;
+
+  @ApiPropertyOptional({
+    description: "Enable email notifications",
+  })
+  @IsBoolean()
+  @IsOptional()
+  emailNotifications?: boolean;
+
+  @ApiPropertyOptional({
+    description: "Enable weekly digest emails",
+  })
+  @IsBoolean()
+  @IsOptional()
+  weeklyDigest?: boolean;
+
+  @ApiPropertyOptional({
+    description: "Enable automatic FACEIT match import",
+  })
+  @IsBoolean()
+  @IsOptional()
+  faceitAutoImport?: boolean;
+
+  @ApiPropertyOptional({
+    description: "Hours between auto-imports",
+    minimum: 1,
+    maximum: 168,
+  })
+  @IsNumber()
+  @Min(1)
+  @Max(168)
+  @IsOptional()
+  faceitImportInterval?: number;
+
+  @ApiPropertyOptional({
+    description: "UI theme preference",
+    enum: ["light", "dark", "system"],
+  })
+  @IsString()
+  @IsOptional()
+  theme?: string;
+
+  @ApiPropertyOptional({
+    description: "Enable compact UI mode",
+  })
+  @IsBoolean()
+  @IsOptional()
+  compactMode?: boolean;
+
+  @ApiPropertyOptional({
+    description: "Show advanced statistics",
+  })
+  @IsBoolean()
+  @IsOptional()
+  showAdvancedStats?: boolean;
+
+  @ApiPropertyOptional({
+    description: "Profile visibility setting",
+    enum: ["PUBLIC", "FRIENDS", "PRIVATE"],
+  })
+  @IsEnum(ProfileVisibility)
+  @IsOptional()
+  profileVisibility?: ProfileVisibility;
+
+  @ApiPropertyOptional({
+    description: "Allow sharing stats with team",
+  })
+  @IsBoolean()
+  @IsOptional()
+  shareStats?: boolean;
+}
+
+// User profile response
+export class UserProfileResponse {
+  @ApiProperty({ description: "User ID" })
+  id!: string;
+
+  @ApiProperty({ description: "User email" })
+  email!: string;
+
+  @ApiPropertyOptional({ description: "Display name" })
+  name?: string | null;
+
+  @ApiPropertyOptional({ description: "Avatar URL" })
+  avatar?: string | null;
+
+  @ApiPropertyOptional({ description: "Steam ID" })
+  steamId?: string | null;
+
+  @ApiPropertyOptional({ description: "FACEIT ID" })
+  faceitId?: string | null;
+
+  @ApiProperty({ description: "Subscription plan" })
+  plan!: string;
+
+  @ApiPropertyOptional({ description: "Plan expiration date" })
+  planExpiresAt?: Date | null;
+
+  @ApiProperty({ description: "Account creation date" })
+  createdAt!: Date;
+}
+
+// User preferences response
+export class UserPreferencesResponse {
+  @ApiProperty({ description: "Preferred dashboard role" })
+  preferredRole!: string;
+
+  @ApiPropertyOptional({ description: "Dashboard layout" })
+  dashboardLayout?: Record<string, unknown> | null;
+
+  @ApiProperty({ description: "Favorite metrics", type: [String] })
+  favoriteMetrics!: string[];
+
+  @ApiProperty({ description: "Default time range" })
+  defaultTimeRange!: string;
+
+  @ApiProperty({ description: "Email notifications enabled" })
+  emailNotifications!: boolean;
+
+  @ApiProperty({ description: "Weekly digest enabled" })
+  weeklyDigest!: boolean;
+
+  @ApiProperty({ description: "Current onboarding step" })
+  onboardingStep!: number;
+
+  @ApiPropertyOptional({ description: "Onboarding completion date" })
+  onboardingCompletedAt?: Date | null;
+
+  @ApiProperty({ description: "Has seen welcome modal" })
+  hasSeenWelcome!: boolean;
+
+  @ApiProperty({ description: "Has completed product tour" })
+  hasCompletedTour!: boolean;
+
+  @ApiProperty({ description: "FACEIT auto-import enabled" })
+  faceitAutoImport!: boolean;
+
+  @ApiProperty({ description: "FACEIT import interval in hours" })
+  faceitImportInterval!: number;
+
+  @ApiProperty({ description: "Theme preference" })
+  theme!: string;
+
+  @ApiProperty({ description: "Compact mode enabled" })
+  compactMode!: boolean;
+
+  @ApiProperty({ description: "Show advanced stats" })
+  showAdvancedStats!: boolean;
+
+  @ApiProperty({ description: "Profile visibility" })
+  profileVisibility!: string;
+
+  @ApiProperty({ description: "Share stats with team" })
+  shareStats!: boolean;
+}
+
+// Onboarding step update DTO
+export class UpdateOnboardingDto {
+  @ApiProperty({
+    description: "Onboarding step number",
+    minimum: 0,
+    maximum: 10,
+  })
+  @IsNumber()
+  @Min(0)
+  @Max(10)
+  step!: number;
+
+  @ApiPropertyOptional({
+    description: "Mark onboarding as completed",
+  })
+  @IsBoolean()
+  @IsOptional()
+  completed?: boolean;
+}
+
+// Dashboard data request DTO
+export class DashboardQueryDto {
+  @ApiPropertyOptional({
+    description: "Time range for data",
+    enum: ["7d", "30d", "90d", "all"],
+    default: "30d",
+  })
+  @IsString()
+  @IsOptional()
+  timeRange?: string;
+
+  @ApiPropertyOptional({
+    description: "Specific team ID to filter by",
+  })
+  @IsString()
+  @IsOptional()
+  teamId?: string;
+
+  @ApiPropertyOptional({
+    description: "Include detailed breakdowns",
+  })
+  @IsBoolean()
+  @IsOptional()
+  detailed?: boolean;
+}

--- a/apps/api/src/modules/user/index.ts
+++ b/apps/api/src/modules/user/index.ts
@@ -1,0 +1,9 @@
+/**
+ * User module exports
+ *
+ * @module user
+ */
+
+export { UserModule } from "./user.module";
+export { UserService } from "./user.service";
+export * from "./dto/user.dto";

--- a/apps/api/src/modules/user/user.controller.ts
+++ b/apps/api/src/modules/user/user.controller.ts
@@ -1,0 +1,190 @@
+/**
+ * User Controller - REST API endpoints for user management
+ *
+ * Endpoints:
+ * - GET  /v1/user/me              - Get current user profile
+ * - GET  /v1/user/me/preferences  - Get user preferences
+ * - PATCH /v1/user/me/preferences - Update user preferences
+ * - GET  /v1/user/me/dashboard/:role - Get role-specific dashboard
+ * - POST /v1/user/me/onboarding   - Update onboarding progress
+ * - POST /v1/user/me/welcome-seen - Mark welcome as seen
+ * - POST /v1/user/me/tour-completed - Mark tour as completed
+ */
+
+import {
+  Controller,
+  Get,
+  Patch,
+  Post,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  Request,
+  BadRequestException,
+} from "@nestjs/common";
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+} from "@nestjs/swagger";
+import { PreferredRole } from "@prisma/client";
+import { UserService } from "./user.service";
+import {
+  UpdatePreferencesDto,
+  UserProfileResponse,
+  UserPreferencesResponse,
+  UpdateOnboardingDto,
+  DashboardQueryDto,
+} from "./dto/user.dto";
+import { JwtAuthGuard } from "../../common/guards/jwt-auth.guard";
+
+// Type for authenticated request
+interface AuthenticatedRequest {
+  user: {
+    id: string;
+    email: string;
+  };
+}
+
+@ApiTags("User")
+@Controller("v1/user")
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class UserController {
+  constructor(private readonly userService: UserService) {}
+
+  /**
+   * Get current user profile
+   */
+  @Get("me")
+  @ApiOperation({ summary: "Get current user profile" })
+  @ApiResponse({ status: 200, description: "User profile", type: UserProfileResponse })
+  @ApiResponse({ status: 401, description: "Unauthorized" })
+  async getProfile(@Request() req: AuthenticatedRequest) {
+    return this.userService.getProfile(req.user.id);
+  }
+
+  /**
+   * Get user preferences
+   */
+  @Get("me/preferences")
+  @ApiOperation({ summary: "Get user preferences" })
+  @ApiResponse({ status: 200, description: "User preferences", type: UserPreferencesResponse })
+  @ApiResponse({ status: 401, description: "Unauthorized" })
+  async getPreferences(@Request() req: AuthenticatedRequest) {
+    return this.userService.getPreferences(req.user.id);
+  }
+
+  /**
+   * Update user preferences
+   */
+  @Patch("me/preferences")
+  @ApiOperation({ summary: "Update user preferences" })
+  @ApiResponse({ status: 200, description: "Updated preferences", type: UserPreferencesResponse })
+  @ApiResponse({ status: 400, description: "Invalid input" })
+  @ApiResponse({ status: 401, description: "Unauthorized" })
+  async updatePreferences(
+    @Request() req: AuthenticatedRequest,
+    @Body() data: UpdatePreferencesDto,
+  ) {
+    return this.userService.updatePreferences(req.user.id, data);
+  }
+
+  /**
+   * Get role-specific dashboard data
+   */
+  @Get("me/dashboard/:role")
+  @ApiOperation({ summary: "Get dashboard data for a specific role" })
+  @ApiParam({
+    name: "role",
+    description: "Dashboard role",
+    enum: ["PLAYER", "COACH", "SCOUT", "ANALYST", "CREATOR"],
+  })
+  @ApiResponse({ status: 200, description: "Dashboard data" })
+  @ApiResponse({ status: 400, description: "Invalid role" })
+  @ApiResponse({ status: 401, description: "Unauthorized" })
+  async getDashboard(
+    @Request() req: AuthenticatedRequest,
+    @Param("role") role: string,
+    @Query() query: DashboardQueryDto,
+  ) {
+    // Validate role
+    const validRoles = Object.values(PreferredRole);
+    if (!validRoles.includes(role as PreferredRole)) {
+      throw new BadRequestException(
+        `Invalid role. Must be one of: ${validRoles.join(", ")}`,
+      );
+    }
+
+    return this.userService.getDashboardData(
+      req.user.id,
+      role as PreferredRole,
+      query,
+    );
+  }
+
+  /**
+   * Get dashboard for user's preferred role
+   */
+  @Get("me/dashboard")
+  @ApiOperation({ summary: "Get dashboard for preferred role" })
+  @ApiResponse({ status: 200, description: "Dashboard data" })
+  @ApiResponse({ status: 401, description: "Unauthorized" })
+  async getPreferredDashboard(
+    @Request() req: AuthenticatedRequest,
+    @Query() query: DashboardQueryDto,
+  ) {
+    const preferences = await this.userService.getPreferences(req.user.id);
+    return this.userService.getDashboardData(
+      req.user.id,
+      preferences.preferredRole as PreferredRole,
+      query,
+    );
+  }
+
+  /**
+   * Update onboarding progress
+   */
+  @Post("me/onboarding")
+  @ApiOperation({ summary: "Update onboarding progress" })
+  @ApiResponse({ status: 200, description: "Onboarding updated" })
+  @ApiResponse({ status: 400, description: "Invalid input" })
+  @ApiResponse({ status: 401, description: "Unauthorized" })
+  async updateOnboarding(
+    @Request() req: AuthenticatedRequest,
+    @Body() data: UpdateOnboardingDto,
+  ) {
+    return this.userService.updateOnboarding(
+      req.user.id,
+      data.step,
+      data.completed,
+    );
+  }
+
+  /**
+   * Mark welcome modal as seen
+   */
+  @Post("me/welcome-seen")
+  @ApiOperation({ summary: "Mark welcome modal as seen" })
+  @ApiResponse({ status: 200, description: "Welcome marked as seen" })
+  @ApiResponse({ status: 401, description: "Unauthorized" })
+  async markWelcomeSeen(@Request() req: AuthenticatedRequest) {
+    await this.userService.markWelcomeSeen(req.user.id);
+    return { success: true };
+  }
+
+  /**
+   * Mark product tour as completed
+   */
+  @Post("me/tour-completed")
+  @ApiOperation({ summary: "Mark product tour as completed" })
+  @ApiResponse({ status: 200, description: "Tour marked as completed" })
+  @ApiResponse({ status: 401, description: "Unauthorized" })
+  async markTourCompleted(@Request() req: AuthenticatedRequest) {
+    await this.userService.markTourCompleted(req.user.id);
+    return { success: true };
+  }
+}

--- a/apps/api/src/modules/user/user.module.ts
+++ b/apps/api/src/modules/user/user.module.ts
@@ -1,0 +1,24 @@
+/**
+ * User Module
+ *
+ * Provides user profile and preferences management.
+ *
+ * Features:
+ * - User profile CRUD
+ * - Preferences management
+ * - Role-specific dashboard aggregation
+ * - Onboarding state tracking
+ *
+ * @module user
+ */
+
+import { Module } from "@nestjs/common";
+import { UserController } from "./user.controller";
+import { UserService } from "./user.service";
+
+@Module({
+  controllers: [UserController],
+  providers: [UserService],
+  exports: [UserService],
+})
+export class UserModule {}

--- a/apps/api/src/modules/user/user.service.ts
+++ b/apps/api/src/modules/user/user.service.ts
@@ -1,0 +1,661 @@
+/**
+ * User Service - Business logic for user management and preferences
+ *
+ * Features:
+ * - User profile management
+ * - Preferences CRUD with defaults
+ * - Dashboard data aggregation by role
+ * - Onboarding state management
+ */
+
+import { Injectable, Logger, NotFoundException } from "@nestjs/common";
+import { PrismaService } from "../../common/prisma";
+import { RedisService } from "../../common/redis";
+import { PreferredRole, Prisma } from "@prisma/client";
+import type {
+  UpdatePreferencesDto,
+  UserPreferencesResponse,
+  DashboardQueryDto,
+} from "./dto/user.dto";
+
+// Dashboard widget type
+export interface DashboardWidget {
+  id: string;
+  type: string;
+  title: string;
+  data: Record<string, unknown>;
+  priority: number;
+}
+
+// Player dashboard data
+export interface PlayerDashboardData {
+  role: "PLAYER";
+  overview: {
+    totalMatches: number;
+    winRate: number;
+    currentRating: number;
+    ratingTrend: number;
+  };
+  strengths: Array<{ name: string; score: number; description: string }>;
+  weaknesses: Array<{ name: string; score: number; suggestion: string }>;
+  recentMatches: Array<{
+    id: string;
+    map: string;
+    result: "win" | "loss" | "draw";
+    rating: number;
+    kills: number;
+    deaths: number;
+    date: Date;
+  }>;
+  nextSteps: Array<{ id: string; title: string; description: string; priority: number }>;
+  widgets: DashboardWidget[];
+}
+
+// Coach dashboard data
+export interface CoachDashboardData {
+  role: "COACH";
+  teamHealth: {
+    averageRating: number;
+    averageRatingTrend: number;
+    totalMatches: number;
+    winRate: number;
+  };
+  playerTiles: Array<{
+    id: string;
+    name: string;
+    avatar: string | null;
+    rating: number;
+    ratingTrend: number;
+    form: "hot" | "normal" | "cold";
+    needsAttention: boolean;
+    topStrength: string;
+    topWeakness: string;
+  }>;
+  teamStrengths: Array<{ name: string; score: number }>;
+  teamWeaknesses: Array<{ name: string; score: number; suggestion: string }>;
+  practiceRecommendations: Array<{ id: string; title: string; description: string }>;
+  widgets: DashboardWidget[];
+}
+
+// Scout dashboard data
+export interface ScoutDashboardData {
+  role: "SCOUT";
+  recentOpponents: Array<{
+    id: string;
+    name: string;
+    tag: string | null;
+    matchCount: number;
+    winRate: number;
+    lastPlayed: Date;
+  }>;
+  upcomingMatches: Array<{
+    id: string;
+    opponent: string;
+    date: Date;
+    hasScoutingReport: boolean;
+  }>;
+  mapMeta: Array<{
+    map: string;
+    pickRate: number;
+    winRate: number;
+    trend: "up" | "stable" | "down";
+  }>;
+  playerWatchlist: Array<{
+    id: string;
+    name: string;
+    team: string;
+    rating: number;
+    role: string;
+  }>;
+  widgets: DashboardWidget[];
+}
+
+// Analyst dashboard data
+export interface AnalystDashboardData {
+  role: "ANALYST";
+  dataOverview: {
+    totalDemos: number;
+    totalRounds: number;
+    dataPoints: number;
+    lastUpdated: Date;
+  };
+  trendingInsights: Array<{
+    id: string;
+    title: string;
+    description: string;
+    type: "positive" | "negative" | "neutral";
+  }>;
+  customReports: Array<{
+    id: string;
+    name: string;
+    lastRun: Date;
+    schedule: string | null;
+  }>;
+  widgets: DashboardWidget[];
+}
+
+export type DashboardData =
+  | PlayerDashboardData
+  | CoachDashboardData
+  | ScoutDashboardData
+  | AnalystDashboardData;
+
+@Injectable()
+export class UserService {
+  private readonly logger = new Logger(UserService.name);
+
+  // Cache TTL for dashboard data (5 minutes in ms)
+  private readonly DASHBOARD_CACHE_TTL = 300000;
+
+  constructor(
+    private prisma: PrismaService,
+    private redis: RedisService,
+  ) {}
+
+  /**
+   * Get user profile by ID
+   */
+  async getProfile(userId: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        avatar: true,
+        steamId: true,
+        faceitId: true,
+        eseaId: true,
+        plan: true,
+        planExpiresAt: true,
+        createdAt: true,
+        teams: {
+          select: {
+            role: true,
+            team: {
+              select: {
+                id: true,
+                name: true,
+                tag: true,
+                logo: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!user) {
+      throw new NotFoundException(`User ${userId} not found`);
+    }
+
+    return user;
+  }
+
+  /**
+   * Get or create user preferences
+   */
+  async getPreferences(userId: string): Promise<UserPreferencesResponse> {
+    // Try to get existing preferences
+    let preferences = await this.prisma.userPreferences.findUnique({
+      where: { userId },
+    });
+
+    // Create default preferences if none exist
+    if (!preferences) {
+      preferences = await this.prisma.userPreferences.create({
+        data: { userId },
+      });
+      this.logger.log(`Created default preferences for user ${userId}`);
+    }
+
+    return {
+      preferredRole: preferences.preferredRole,
+      dashboardLayout: preferences.dashboardLayout as Record<string, unknown> | null,
+      favoriteMetrics: preferences.favoriteMetrics,
+      defaultTimeRange: preferences.defaultTimeRange,
+      emailNotifications: preferences.emailNotifications,
+      weeklyDigest: preferences.weeklyDigest,
+      onboardingStep: preferences.onboardingStep,
+      onboardingCompletedAt: preferences.onboardingCompletedAt,
+      hasSeenWelcome: preferences.hasSeenWelcome,
+      hasCompletedTour: preferences.hasCompletedTour,
+      faceitAutoImport: preferences.faceitAutoImport,
+      faceitImportInterval: preferences.faceitImportInterval,
+      theme: preferences.theme,
+      compactMode: preferences.compactMode,
+      showAdvancedStats: preferences.showAdvancedStats,
+      profileVisibility: preferences.profileVisibility,
+      shareStats: preferences.shareStats,
+    };
+  }
+
+  /**
+   * Update user preferences
+   */
+  async updatePreferences(
+    userId: string,
+    data: UpdatePreferencesDto,
+  ): Promise<UserPreferencesResponse> {
+    // Ensure user exists
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) {
+      throw new NotFoundException(`User ${userId} not found`);
+    }
+
+    // Build update data, excluding undefined values
+    const updateData: Prisma.UserPreferencesUpdateInput = {};
+
+    if (data.preferredRole !== undefined) updateData.preferredRole = data.preferredRole;
+    if (data.dashboardLayout !== undefined) {
+      updateData.dashboardLayout = data.dashboardLayout as Prisma.InputJsonValue;
+    }
+    if (data.favoriteMetrics !== undefined) updateData.favoriteMetrics = data.favoriteMetrics;
+    if (data.defaultTimeRange !== undefined) updateData.defaultTimeRange = data.defaultTimeRange;
+    if (data.emailNotifications !== undefined) updateData.emailNotifications = data.emailNotifications;
+    if (data.weeklyDigest !== undefined) updateData.weeklyDigest = data.weeklyDigest;
+    if (data.faceitAutoImport !== undefined) updateData.faceitAutoImport = data.faceitAutoImport;
+    if (data.faceitImportInterval !== undefined) updateData.faceitImportInterval = data.faceitImportInterval;
+    if (data.theme !== undefined) updateData.theme = data.theme;
+    if (data.compactMode !== undefined) updateData.compactMode = data.compactMode;
+    if (data.showAdvancedStats !== undefined) updateData.showAdvancedStats = data.showAdvancedStats;
+    if (data.profileVisibility !== undefined) updateData.profileVisibility = data.profileVisibility;
+    if (data.shareStats !== undefined) updateData.shareStats = data.shareStats;
+
+    // Upsert preferences
+    await this.prisma.userPreferences.upsert({
+      where: { userId },
+      create: {
+        userId,
+        ...(data.preferredRole && { preferredRole: data.preferredRole }),
+        ...(data.dashboardLayout && { dashboardLayout: data.dashboardLayout as Prisma.InputJsonValue }),
+        ...(data.favoriteMetrics && { favoriteMetrics: data.favoriteMetrics }),
+        ...(data.defaultTimeRange && { defaultTimeRange: data.defaultTimeRange }),
+        ...(data.emailNotifications !== undefined && { emailNotifications: data.emailNotifications }),
+        ...(data.weeklyDigest !== undefined && { weeklyDigest: data.weeklyDigest }),
+        ...(data.faceitAutoImport !== undefined && { faceitAutoImport: data.faceitAutoImport }),
+        ...(data.faceitImportInterval && { faceitImportInterval: data.faceitImportInterval }),
+        ...(data.theme && { theme: data.theme }),
+        ...(data.compactMode !== undefined && { compactMode: data.compactMode }),
+        ...(data.showAdvancedStats !== undefined && { showAdvancedStats: data.showAdvancedStats }),
+        ...(data.profileVisibility && { profileVisibility: data.profileVisibility }),
+        ...(data.shareStats !== undefined && { shareStats: data.shareStats }),
+      },
+      update: updateData,
+    });
+
+    // Invalidate dashboard cache
+    await this.invalidateDashboardCache(userId);
+
+    this.logger.log(`Updated preferences for user ${userId}`);
+
+    return this.getPreferences(userId);
+  }
+
+  /**
+   * Update onboarding progress
+   */
+  async updateOnboarding(
+    userId: string,
+    step: number,
+    completed = false,
+  ): Promise<{ step: number; completed: boolean }> {
+    const updateData: Prisma.UserPreferencesUpdateInput = {
+      onboardingStep: step,
+    };
+
+    if (completed) {
+      updateData.onboardingCompletedAt = new Date();
+    }
+
+    await this.prisma.userPreferences.upsert({
+      where: { userId },
+      create: {
+        userId,
+        onboardingStep: step,
+        ...(completed && { onboardingCompletedAt: new Date() }),
+      },
+      update: updateData,
+    });
+
+    return { step, completed };
+  }
+
+  /**
+   * Mark welcome modal as seen
+   */
+  async markWelcomeSeen(userId: string): Promise<void> {
+    await this.prisma.userPreferences.upsert({
+      where: { userId },
+      create: { userId, hasSeenWelcome: true },
+      update: { hasSeenWelcome: true },
+    });
+  }
+
+  /**
+   * Mark product tour as completed
+   */
+  async markTourCompleted(userId: string): Promise<void> {
+    await this.prisma.userPreferences.upsert({
+      where: { userId },
+      create: { userId, hasCompletedTour: true },
+      update: { hasCompletedTour: true },
+    });
+  }
+
+  /**
+   * Get dashboard data for a specific role
+   */
+  async getDashboardData(
+    userId: string,
+    role: PreferredRole,
+    query: DashboardQueryDto,
+  ): Promise<DashboardData> {
+    // Check cache first
+    const cacheKey = `dashboard:${userId}:${role}:${query.timeRange || "30d"}`;
+    const cached = await this.redis.get<DashboardData>(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    // Get user profile
+    const user = await this.getProfile(userId);
+
+    // Generate role-specific dashboard
+    let dashboardData: DashboardData;
+
+    switch (role) {
+      case PreferredRole.PLAYER:
+        dashboardData = await this.getPlayerDashboard(user.steamId, query);
+        break;
+      case PreferredRole.COACH:
+        dashboardData = await this.getCoachDashboard(userId, query);
+        break;
+      case PreferredRole.SCOUT:
+        dashboardData = await this.getScoutDashboard(query);
+        break;
+      case PreferredRole.ANALYST:
+        dashboardData = await this.getAnalystDashboard(query);
+        break;
+      default:
+        dashboardData = await this.getPlayerDashboard(user.steamId, query);
+    }
+
+    // Cache result
+    await this.redis.set(cacheKey, dashboardData, this.DASHBOARD_CACHE_TTL);
+
+    return dashboardData;
+  }
+
+  /**
+   * Generate player-focused dashboard
+   */
+  private async getPlayerDashboard(
+    steamId: string | null,
+    query: DashboardQueryDto,
+  ): Promise<PlayerDashboardData> {
+    const timeRange = this.parseTimeRange(query.timeRange || "30d");
+
+    // Get player stats if steamId is available
+    let stats: Array<{
+      kills: number;
+      deaths: number;
+      teamNum: number;
+      demo: {
+        id: string;
+        mapName: string;
+        parsedAt: Date | null;
+        team1Score: number;
+        team2Score: number;
+      };
+    }> = [];
+
+    if (steamId) {
+      stats = await this.prisma.matchPlayerStats.findMany({
+        where: {
+          steamId,
+          demo: {
+            parsedAt: { gte: timeRange.start },
+          },
+        },
+        include: {
+          demo: {
+            select: {
+              id: true,
+              mapName: true,
+              parsedAt: true,
+              team1Score: true,
+              team2Score: true,
+            },
+          },
+        },
+        orderBy: { demo: { parsedAt: "desc" } },
+        take: 20,
+      });
+    }
+
+    // Calculate overview
+    const totalMatches = stats.length;
+    const wins = stats.filter((s) => this.isWin(s)).length;
+    const winRate = totalMatches > 0 ? (wins / totalMatches) * 100 : 0;
+
+    // Rating calculation (simplified - would use actual rating from analysis)
+    const currentRating = 1.0 + (winRate - 50) / 100;
+    const ratingTrend = 0.02; // Placeholder
+
+    // Build recent matches
+    const recentMatches = stats.slice(0, 5).map((s) => ({
+      id: s.demo.id,
+      map: s.demo.mapName,
+      result: this.isWin(s) ? "win" as const : "loss" as const,
+      rating: currentRating,
+      kills: s.kills,
+      deaths: s.deaths,
+      date: s.demo.parsedAt || new Date(),
+    }));
+
+    return {
+      role: "PLAYER",
+      overview: {
+        totalMatches,
+        winRate: Math.round(winRate * 10) / 10,
+        currentRating: Math.round(currentRating * 100) / 100,
+        ratingTrend,
+      },
+      strengths: [
+        { name: "Aim", score: 75, description: "Your headshot percentage is above average" },
+        { name: "Trade Fragging", score: 68, description: "You often get refrag opportunities" },
+      ],
+      weaknesses: [
+        { name: "Utility Usage", score: 45, suggestion: "Use more flashes before pushing" },
+        { name: "Economy Management", score: 52, suggestion: "Avoid force-buying on 3rd round loss" },
+      ],
+      recentMatches,
+      nextSteps: [
+        { id: "1", title: "Watch your recent demos", description: "Review your last 3 matches for mistakes", priority: 1 },
+        { id: "2", title: "Practice utility", description: "Learn 3 new smokes for your favorite map", priority: 2 },
+      ],
+      widgets: [],
+    };
+  }
+
+  /**
+   * Generate coach-focused dashboard
+   */
+  private async getCoachDashboard(
+    userId: string,
+    _query: DashboardQueryDto,
+  ): Promise<CoachDashboardData> {
+    // Get user's teams
+    const teamMemberships = await this.prisma.teamMember.findMany({
+      where: { userId },
+      include: {
+        team: {
+          include: {
+            members: {
+              include: {
+                user: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const team = teamMemberships[0]?.team;
+    const players = team?.members.filter((m) => m.role === "PLAYER") || [];
+
+    // Build player tiles
+    const playerTiles = players.map((member) => ({
+      id: member.user.id,
+      name: member.user.name || "Unknown",
+      avatar: member.user.avatar,
+      rating: 1.05, // Would calculate from actual data
+      ratingTrend: 0.02,
+      form: "normal" as const,
+      needsAttention: false,
+      topStrength: "Aim",
+      topWeakness: "Utility",
+    }));
+
+    return {
+      role: "COACH",
+      teamHealth: {
+        averageRating: 1.05,
+        averageRatingTrend: 0.01,
+        totalMatches: 15,
+        winRate: 60,
+      },
+      playerTiles,
+      teamStrengths: [
+        { name: "Pistol Rounds", score: 72 },
+        { name: "CT Side", score: 68 },
+      ],
+      teamWeaknesses: [
+        { name: "Anti-eco", score: 45, suggestion: "Review anti-eco setups" },
+        { name: "Late round situations", score: 48, suggestion: "Practice clutch scenarios" },
+      ],
+      practiceRecommendations: [
+        { id: "1", title: "CT Retakes on Mirage", description: "Win rate below average" },
+        { id: "2", title: "T Side Executes on Inferno", description: "Post-plant situations need work" },
+      ],
+      widgets: [],
+    };
+  }
+
+  /**
+   * Generate scout-focused dashboard
+   */
+  private async getScoutDashboard(
+    _query: DashboardQueryDto,
+  ): Promise<ScoutDashboardData> {
+    return {
+      role: "SCOUT",
+      recentOpponents: [
+        {
+          id: "1",
+          name: "Team Liquid",
+          tag: "TL",
+          matchCount: 3,
+          winRate: 33,
+          lastPlayed: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+        },
+      ],
+      upcomingMatches: [],
+      mapMeta: [
+        { map: "de_mirage", pickRate: 25, winRate: 55, trend: "stable" },
+        { map: "de_inferno", pickRate: 22, winRate: 48, trend: "down" },
+        { map: "de_dust2", pickRate: 18, winRate: 62, trend: "up" },
+      ],
+      playerWatchlist: [],
+      widgets: [],
+    };
+  }
+
+  /**
+   * Generate analyst-focused dashboard
+   */
+  private async getAnalystDashboard(
+    _query: DashboardQueryDto,
+  ): Promise<AnalystDashboardData> {
+    // Get data statistics
+    const [demoCount, roundCount] = await Promise.all([
+      this.prisma.demo.count({ where: { status: "COMPLETED" } }),
+      this.prisma.round.count(),
+    ]);
+
+    return {
+      role: "ANALYST",
+      dataOverview: {
+        totalDemos: demoCount,
+        totalRounds: roundCount,
+        dataPoints: roundCount * 100, // Approximate
+        lastUpdated: new Date(),
+      },
+      trendingInsights: [
+        {
+          id: "1",
+          title: "Smoke usage increased",
+          description: "Your team is using 15% more smokes this month",
+          type: "positive",
+        },
+        {
+          id: "2",
+          title: "AWP impact declining",
+          description: "AWP kills per round down from 0.8 to 0.6",
+          type: "negative",
+        },
+      ],
+      customReports: [],
+      widgets: [],
+    };
+  }
+
+  /**
+   * Parse time range string to date range
+   */
+  private parseTimeRange(range: string): { start: Date; end: Date } {
+    const end = new Date();
+    const start = new Date();
+
+    switch (range) {
+      case "7d":
+        start.setDate(end.getDate() - 7);
+        break;
+      case "30d":
+        start.setDate(end.getDate() - 30);
+        break;
+      case "90d":
+        start.setDate(end.getDate() - 90);
+        break;
+      case "all":
+        start.setFullYear(2020); // CS2 release
+        break;
+      default:
+        start.setDate(end.getDate() - 30);
+    }
+
+    return { start, end };
+  }
+
+  /**
+   * Check if a match was a win for the player
+   */
+  private isWin(
+    stats: { teamNum: number; demo: { team1Score: number; team2Score: number } },
+  ): boolean {
+    const { teamNum, demo } = stats;
+    if (teamNum === 2) {
+      return demo.team1Score > demo.team2Score;
+    }
+    return demo.team2Score > demo.team1Score;
+  }
+
+  /**
+   * Invalidate dashboard cache for a user
+   */
+  private async invalidateDashboardCache(userId: string): Promise<void> {
+    const pattern = `dashboard:${userId}:*`;
+    await this.redis.deletePattern(pattern);
+  }
+}

--- a/apps/web/src/components/dashboard/coach/coach-dashboard.tsx
+++ b/apps/web/src/components/dashboard/coach/coach-dashboard.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+/**
+ * Coach Dashboard
+ *
+ * Team management focused dashboard showing:
+ * - Team health overview (overall rating, trend)
+ * - Player tiles with individual ratings
+ * - Alerts for players needing attention
+ *
+ * @module components/dashboard/coach/coach-dashboard
+ */
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { RatingBadge, getRatingTier } from "@/components/rating/rating-badge";
+import { type DashboardData, type CoachDashboardData } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import {
+  TrendingUp,
+  TrendingDown,
+  Users,
+  AlertCircle,
+  Info,
+  AlertTriangle,
+  User,
+  ArrowRight,
+  Activity,
+} from "lucide-react";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface CoachDashboardProps {
+  data: DashboardData;
+  className?: string;
+}
+
+// ============================================================================
+// Helper Components
+// ============================================================================
+
+function TrendIndicator({ value }: { value: number }) {
+  const isPositive = value >= 0;
+  const Icon = isPositive ? TrendingUp : TrendingDown;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1 text-sm",
+        isPositive ? "text-green-500" : "text-red-500",
+      )}
+    >
+      <Icon className="h-4 w-4" />
+      <span>{isPositive ? "+" : ""}{(value * 100).toFixed(1)}%</span>
+    </div>
+  );
+}
+
+// ============================================================================
+// Team Health Card
+// ============================================================================
+
+function TeamHealthCard({
+  teamHealth,
+}: {
+  teamHealth: CoachDashboardData["teamHealth"];
+}) {
+  const tier = getRatingTier(teamHealth.overallRating);
+
+  // Calculate health percentage (0.5-2.0 range mapped to 0-100%)
+  const healthPercent = Math.min(
+    100,
+    Math.max(0, ((teamHealth.overallRating - 0.5) / 1.5) * 100),
+  );
+
+  // Determine health status
+  const healthStatus =
+    teamHealth.overallRating >= 1.1
+      ? { label: "Excellent", color: "text-green-500" }
+      : teamHealth.overallRating >= 1.0
+        ? { label: "Good", color: "text-emerald-500" }
+        : teamHealth.overallRating >= 0.9
+          ? { label: "Average", color: "text-yellow-500" }
+          : { label: "Needs Attention", color: "text-red-500" };
+
+  return (
+    <Card className="col-span-full lg:col-span-2">
+      <CardHeader className="pb-2">
+        <CardDescription>Team Overview</CardDescription>
+        <CardTitle className="flex items-center justify-between">
+          <span>Team Health</span>
+          <Activity className="h-5 w-5 text-muted-foreground" />
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center justify-between mb-4">
+          <div className="space-y-1">
+            <div className="flex items-baseline gap-3">
+              <RatingBadge rating={teamHealth.overallRating} size="xl" />
+              <TrendIndicator value={teamHealth.trend} />
+            </div>
+            <p className={cn("text-sm font-medium", healthStatus.color)}>
+              {healthStatus.label}
+            </p>
+          </div>
+          <div className="text-right">
+            <div className="flex items-center gap-2 text-3xl font-bold">
+              <Users className="h-6 w-6 text-muted-foreground" />
+              {teamHealth.playerCount}
+            </div>
+            <p className="text-sm text-muted-foreground">active players</p>
+          </div>
+        </div>
+
+        {/* Health bar */}
+        <div className="space-y-2">
+          <div className="flex justify-between text-sm">
+            <span className="text-muted-foreground">Team Rating</span>
+            <span className={cn("font-medium", tier.textColor)}>{tier.label}</span>
+          </div>
+          <Progress value={healthPercent} className="h-3" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ============================================================================
+// Player Tiles
+// ============================================================================
+
+function PlayerTile({
+  player,
+}: {
+  player: CoachDashboardData["playerTiles"][0];
+}) {
+  const tier = getRatingTier(player.rating);
+  const isImproving = player.trend > 0;
+
+  return (
+    <Card className="hover:bg-accent/50 transition-colors cursor-pointer">
+      <CardContent className="p-4">
+        <div className="flex items-center gap-3">
+          {/* Avatar */}
+          <div className="relative">
+            <div className="h-10 w-10 rounded-full bg-muted flex items-center justify-center overflow-hidden">
+              {player.avatar ? (
+                <img
+                  src={player.avatar}
+                  alt={player.name}
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                <User className="h-5 w-5 text-muted-foreground" />
+              )}
+            </div>
+            {/* Trend indicator dot */}
+            <div
+              className={cn(
+                "absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-background",
+                isImproving ? "bg-green-500" : "bg-red-500",
+              )}
+            />
+          </div>
+
+          {/* Info */}
+          <div className="flex-1 min-w-0">
+            <p className="font-medium truncate">{player.name}</p>
+            <div className="flex items-center gap-2">
+              <RatingBadge rating={player.rating} size="sm" />
+              <span className={cn("text-xs", tier.textColor)}>{tier.label}</span>
+            </div>
+          </div>
+
+          {/* Trend */}
+          <TrendIndicator value={player.trend} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function PlayerTilesCard({
+  players,
+}: {
+  players: CoachDashboardData["playerTiles"];
+}) {
+  return (
+    <Card className="col-span-full lg:col-span-2">
+      <CardHeader className="pb-2">
+        <CardDescription>Individual Performance</CardDescription>
+        <CardTitle className="flex items-center justify-between">
+          <span>Players</span>
+          <Button variant="ghost" size="sm" className="gap-1">
+            View all
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-3 sm:grid-cols-2">
+          {players.length > 0 ? (
+            players.slice(0, 6).map((player) => (
+              <PlayerTile key={player.steamId} player={player} />
+            ))
+          ) : (
+            <p className="text-sm text-muted-foreground col-span-full text-center py-8">
+              No players tracked yet. Add team members to see their performance.
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ============================================================================
+// Alerts Card
+// ============================================================================
+
+const ALERT_ICONS = {
+  info: Info,
+  warning: AlertTriangle,
+  error: AlertCircle,
+};
+
+const ALERT_STYLES = {
+  info: "bg-blue-500/10 border-blue-500/20 text-blue-600",
+  warning: "bg-amber-500/10 border-amber-500/20 text-amber-600",
+  error: "bg-red-500/10 border-red-500/20 text-red-600",
+};
+
+function AlertsCard({ alerts }: { alerts: CoachDashboardData["alerts"] }) {
+  return (
+    <Card className="col-span-full">
+      <CardHeader className="pb-2">
+        <CardDescription>Action Items</CardDescription>
+        <CardTitle className="flex items-center justify-between">
+          <span>Team Alerts</span>
+          {alerts.length > 0 && (
+            <span className="text-sm font-normal text-muted-foreground">
+              {alerts.length} active
+            </span>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {alerts.length > 0 ? (
+          <div className="space-y-2">
+            {alerts.slice(0, 5).map((alert, index) => {
+              const Icon = ALERT_ICONS[alert.severity];
+              const style = ALERT_STYLES[alert.severity];
+
+              return (
+                <div
+                  key={index}
+                  className={cn(
+                    "flex items-start gap-3 p-3 rounded-lg border",
+                    style,
+                  )}
+                >
+                  <Icon className="h-5 w-5 mt-0.5 shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium">{alert.type}</p>
+                    <p className="text-sm opacity-80">{alert.message}</p>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="text-center py-8">
+            <div className="h-12 w-12 rounded-full bg-green-500/10 flex items-center justify-center mx-auto mb-3">
+              <Activity className="h-6 w-6 text-green-500" />
+            </div>
+            <p className="font-medium">All systems healthy</p>
+            <p className="text-sm text-muted-foreground">
+              No alerts requiring your attention
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+export function CoachDashboard({ data, className }: CoachDashboardProps) {
+  // Type guard for coach dashboard data
+  const coachData = data.data as CoachDashboardData;
+
+  return (
+    <div className={cn("grid gap-4 md:grid-cols-2 lg:grid-cols-4", className)}>
+      {/* Team health overview */}
+      <TeamHealthCard teamHealth={coachData.teamHealth} />
+
+      {/* Player tiles */}
+      <PlayerTilesCard players={coachData.playerTiles} />
+
+      {/* Alerts */}
+      <AlertsCard alerts={coachData.alerts} />
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/coach/index.ts
+++ b/apps/web/src/components/dashboard/coach/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Coach Dashboard exports
+ *
+ * @module components/dashboard/coach
+ */
+
+export { CoachDashboard } from "./coach-dashboard";

--- a/apps/web/src/components/dashboard/dashboard-router.tsx
+++ b/apps/web/src/components/dashboard/dashboard-router.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+/**
+ * Dashboard Router
+ *
+ * Routes to the appropriate role-based dashboard based on user preferences.
+ * Handles loading states, error states, and role switching.
+ *
+ * @module components/dashboard/dashboard-router
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { usePreferences } from "@/hooks/use-preferences";
+import { type PreferredRole } from "@/stores/preferences-store";
+import { userApi, type DashboardData } from "@/lib/api";
+import { DashboardSwitcher } from "./dashboard-switcher";
+import { PlayerDashboard } from "./player/player-dashboard";
+import { CoachDashboard } from "./coach/coach-dashboard";
+import { ScoutDashboard } from "./scout/scout-dashboard";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { Loader2, AlertCircle, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface DashboardRouterProps {
+  className?: string;
+  initialRole?: PreferredRole;
+}
+
+// ============================================================================
+// Loading State Component
+// ============================================================================
+
+function DashboardSkeleton() {
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 animate-pulse">
+      {[1, 2, 3, 4].map((i) => (
+        <Card key={i} className="h-32">
+          <CardContent className="p-6">
+            <div className="h-4 bg-muted rounded w-1/2 mb-2" />
+            <div className="h-8 bg-muted rounded w-3/4" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+// ============================================================================
+// Error State Component
+// ============================================================================
+
+function DashboardError({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <Card className="border-destructive/50 bg-destructive/5">
+      <CardContent className="flex flex-col items-center justify-center py-12">
+        <AlertCircle className="h-12 w-12 text-destructive mb-4" />
+        <h3 className="text-lg font-semibold mb-2">Failed to load dashboard</h3>
+        <p className="text-muted-foreground text-center mb-4 max-w-md">
+          {message}
+        </p>
+        <Button variant="outline" onClick={onRetry} className="gap-2">
+          <RefreshCw className="h-4 w-4" />
+          Try again
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+export function DashboardRouter({
+  className,
+  initialRole,
+}: DashboardRouterProps) {
+  const {
+    preferredRole,
+    setPreferredRole,
+    isLoading: isPreferencesLoading,
+    isSaving,
+  } = usePreferences();
+
+  const [activeRole, setActiveRole] = useState<PreferredRole>(
+    initialRole ?? preferredRole,
+  );
+  const [dashboardData, setDashboardData] = useState<DashboardData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Sync with preferences when they change
+  useEffect(() => {
+    if (!initialRole && preferredRole !== activeRole) {
+      setActiveRole(preferredRole);
+    }
+  }, [preferredRole, initialRole, activeRole]);
+
+  // Fetch dashboard data
+  const fetchDashboard = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const data = await userApi.getDashboard(activeRole);
+      setDashboardData(data);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load dashboard data",
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [activeRole]);
+
+  // Fetch on mount and role change
+  useEffect(() => {
+    fetchDashboard();
+  }, [fetchDashboard]);
+
+  // Handle role change
+  const handleRoleChange = useCallback(
+    async (role: PreferredRole) => {
+      setActiveRole(role);
+      // Persist to preferences
+      await setPreferredRole(role);
+    },
+    [setPreferredRole],
+  );
+
+  // Render appropriate dashboard based on role
+  const renderDashboard = () => {
+    if (isLoading || isPreferencesLoading) {
+      return <DashboardSkeleton />;
+    }
+
+    if (error) {
+      return <DashboardError message={error} onRetry={fetchDashboard} />;
+    }
+
+    if (!dashboardData) {
+      return <DashboardSkeleton />;
+    }
+
+    switch (activeRole) {
+      case "PLAYER":
+        return <PlayerDashboard data={dashboardData} />;
+      case "COACH":
+        return <CoachDashboard data={dashboardData} />;
+      case "SCOUT":
+        return <ScoutDashboard data={dashboardData} />;
+      case "ANALYST":
+        // TODO: Implement AnalystDashboard
+        return <PlayerDashboard data={dashboardData} />;
+      case "CREATOR":
+        // TODO: Implement CreatorDashboard
+        return <PlayerDashboard data={dashboardData} />;
+      default:
+        return <PlayerDashboard data={dashboardData} />;
+    }
+  };
+
+  return (
+    <div className={cn("space-y-6", className)}>
+      {/* Header with switcher */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Dashboard</h1>
+          <p className="text-muted-foreground">
+            Your personalized CS2 analytics overview
+          </p>
+        </div>
+
+        <div className="flex items-center gap-3">
+          {isSaving && (
+            <span className="text-xs text-muted-foreground flex items-center gap-1">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              Saving...
+            </span>
+          )}
+          <DashboardSwitcher
+            currentRole={activeRole}
+            onRoleChange={handleRoleChange}
+            isLoading={isLoading}
+          />
+        </div>
+      </div>
+
+      {/* Dashboard content */}
+      {renderDashboard()}
+    </div>
+  );
+}
+
+// ============================================================================
+// Export
+// ============================================================================
+
+export { DashboardSwitcher } from "./dashboard-switcher";

--- a/apps/web/src/components/dashboard/dashboard-switcher.tsx
+++ b/apps/web/src/components/dashboard/dashboard-switcher.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+/**
+ * Dashboard Role Switcher
+ *
+ * Dropdown component for switching between different role-based dashboards.
+ * Shows current role and allows quick switching with role descriptions.
+ *
+ * @module components/dashboard/dashboard-switcher
+ */
+
+import { useCallback, useState } from "react";
+import { ChevronDown, User, Users, Search, BarChart3, Video } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  type PreferredRole,
+  ROLE_METADATA,
+} from "@/stores/preferences-store";
+import { cn } from "@/lib/utils";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface DashboardSwitcherProps {
+  currentRole: PreferredRole;
+  onRoleChange: (role: PreferredRole) => void;
+  isLoading?: boolean;
+  disabled?: boolean;
+  className?: string;
+}
+
+// ============================================================================
+// Icon mapping
+// ============================================================================
+
+const ROLE_ICONS: Record<PreferredRole, React.ComponentType<{ className?: string }>> = {
+  PLAYER: User,
+  COACH: Users,
+  SCOUT: Search,
+  ANALYST: BarChart3,
+  CREATOR: Video,
+};
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function DashboardSwitcher({
+  currentRole,
+  onRoleChange,
+  isLoading = false,
+  disabled = false,
+  className,
+}: DashboardSwitcherProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const currentMeta = ROLE_METADATA[currentRole];
+  const CurrentIcon = ROLE_ICONS[currentRole];
+
+  const handleRoleSelect = useCallback(
+    (role: PreferredRole) => {
+      if (role !== currentRole) {
+        onRoleChange(role);
+      }
+      setIsOpen(false);
+    },
+    [currentRole, onRoleChange],
+  );
+
+  const roles = Object.entries(ROLE_METADATA) as [PreferredRole, typeof currentMeta][];
+
+  return (
+    <div className={cn("relative", className)}>
+      {/* Trigger Button */}
+      <Button
+        variant="outline"
+        role="combobox"
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+        disabled={disabled || isLoading}
+        onClick={() => setIsOpen(!isOpen)}
+        className={cn(
+          "w-full justify-between min-w-[200px]",
+          isLoading && "opacity-70",
+        )}
+      >
+        <div className="flex items-center gap-2">
+          <CurrentIcon className="h-4 w-4 text-muted-foreground" />
+          <span>{currentMeta.label} Dashboard</span>
+        </div>
+        <ChevronDown
+          className={cn(
+            "ml-2 h-4 w-4 shrink-0 opacity-50 transition-transform",
+            isOpen && "rotate-180",
+          )}
+        />
+      </Button>
+
+      {/* Dropdown Menu */}
+      {isOpen && (
+        <>
+          {/* Backdrop */}
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => setIsOpen(false)}
+          />
+
+          {/* Menu */}
+          <div
+            role="listbox"
+            className={cn(
+              "absolute top-full left-0 right-0 z-50 mt-1",
+              "bg-popover border rounded-md shadow-lg",
+              "animate-in fade-in-0 zoom-in-95",
+            )}
+          >
+            {roles.map(([role, meta]) => {
+              const Icon = ROLE_ICONS[role];
+              const isSelected = role === currentRole;
+
+              return (
+                <button
+                  key={role}
+                  role="option"
+                  aria-selected={isSelected}
+                  onClick={() => handleRoleSelect(role)}
+                  className={cn(
+                    "w-full flex items-start gap-3 p-3 text-left",
+                    "hover:bg-accent transition-colors",
+                    "first:rounded-t-md last:rounded-b-md",
+                    isSelected && "bg-accent/50",
+                  )}
+                >
+                  <Icon
+                    className={cn(
+                      "h-5 w-5 mt-0.5",
+                      isSelected ? "text-primary" : "text-muted-foreground",
+                    )}
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium">{meta.label}</span>
+                      {isSelected && (
+                        <span className="text-xs bg-primary/10 text-primary px-1.5 py-0.5 rounded">
+                          Current
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-sm text-muted-foreground mt-0.5 line-clamp-1">
+                      {meta.description}
+                    </p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Compact variant for sidebar/header
+// ============================================================================
+
+interface CompactSwitcherProps {
+  currentRole: PreferredRole;
+  onRoleChange: (role: PreferredRole) => void;
+  className?: string;
+}
+
+export function CompactRoleSwitcher({
+  currentRole,
+  onRoleChange,
+  className,
+}: CompactSwitcherProps) {
+  const roles: PreferredRole[] = ["PLAYER", "COACH", "SCOUT", "ANALYST", "CREATOR"];
+
+  return (
+    <div className={cn("flex gap-1", className)}>
+      {roles.map((role) => {
+        const Icon = ROLE_ICONS[role];
+        const isSelected = role === currentRole;
+
+        return (
+          <button
+            key={role}
+            onClick={() => onRoleChange(role)}
+            title={ROLE_METADATA[role].label}
+            className={cn(
+              "p-2 rounded-md transition-colors",
+              isSelected
+                ? "bg-primary text-primary-foreground"
+                : "hover:bg-accent text-muted-foreground",
+            )}
+          >
+            <Icon className="h-4 w-4" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/index.ts
+++ b/apps/web/src/components/dashboard/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Dashboard exports
+ *
+ * Central export point for all dashboard components
+ *
+ * @module components/dashboard
+ */
+
+// Main components
+export { DashboardRouter } from "./dashboard-router";
+export { DashboardSwitcher, CompactRoleSwitcher } from "./dashboard-switcher";
+
+// Role-specific dashboards
+export { PlayerDashboard } from "./player";
+export { CoachDashboard } from "./coach";
+export { ScoutDashboard } from "./scout";

--- a/apps/web/src/components/dashboard/player/index.ts
+++ b/apps/web/src/components/dashboard/player/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Player Dashboard exports
+ *
+ * @module components/dashboard/player
+ */
+
+export { PlayerDashboard } from "./player-dashboard";

--- a/apps/web/src/components/dashboard/player/player-dashboard.tsx
+++ b/apps/web/src/components/dashboard/player/player-dashboard.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+/**
+ * Player Dashboard
+ *
+ * Personal improvement focused dashboard showing:
+ * - Current rating with trend
+ * - Strengths (what you're good at)
+ * - Weaknesses (areas to improve)
+ * - Next actionable step
+ *
+ * @module components/dashboard/player/player-dashboard
+ */
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { RatingBadge, getRatingTier } from "@/components/rating/rating-badge";
+import { type DashboardData, type PlayerDashboardData } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import {
+  TrendingUp,
+  TrendingDown,
+  Target,
+  Zap,
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle2,
+  Trophy,
+} from "lucide-react";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface PlayerDashboardProps {
+  data: DashboardData;
+  className?: string;
+}
+
+// ============================================================================
+// Helper Components
+// ============================================================================
+
+function TrendIndicator({ value }: { value: number }) {
+  const isPositive = value >= 0;
+  const Icon = isPositive ? TrendingUp : TrendingDown;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1 text-sm",
+        isPositive ? "text-green-500" : "text-red-500",
+      )}
+    >
+      <Icon className="h-4 w-4" />
+      <span>{isPositive ? "+" : ""}{(value * 100).toFixed(1)}%</span>
+    </div>
+  );
+}
+
+// ============================================================================
+// Rating Card
+// ============================================================================
+
+function RatingOverviewCard({
+  rating,
+  recentMatches,
+}: {
+  rating: PlayerDashboardData["rating"];
+  recentMatches: number;
+}) {
+  const tier = getRatingTier(rating.current);
+
+  return (
+    <Card className="col-span-full lg:col-span-2">
+      <CardHeader className="pb-2">
+        <CardDescription>Current Performance</CardDescription>
+        <CardTitle className="flex items-center justify-between">
+          <span>Your Rating</span>
+          <Trophy className="h-5 w-5 text-muted-foreground" />
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center justify-between">
+          <div className="space-y-1">
+            <div className="flex items-baseline gap-3">
+              <RatingBadge rating={rating.current} size="xl" />
+              <TrendIndicator value={rating.trend} />
+            </div>
+            <p className={cn("text-sm font-medium", tier.textColor)}>
+              {rating.label}
+            </p>
+          </div>
+          <div className="text-right">
+            <p className="text-3xl font-bold">{recentMatches}</p>
+            <p className="text-sm text-muted-foreground">recent matches</p>
+          </div>
+        </div>
+
+        {/* Rating progress to next tier */}
+        <div className="mt-4 space-y-2">
+          <div className="flex justify-between text-sm">
+            <span className="text-muted-foreground">Progress to {tier.label}</span>
+            <span className="font-medium">
+              {Math.round(((rating.current - 0.5) / 1.5) * 100)}%
+            </span>
+          </div>
+          <Progress value={((rating.current - 0.5) / 1.5) * 100} className="h-2" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ============================================================================
+// Strengths Card
+// ============================================================================
+
+function StrengthsCard({ strengths }: { strengths: string[] }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardDescription>Keep it up!</CardDescription>
+        <CardTitle className="flex items-center justify-between">
+          <span>Your Strengths</span>
+          <Zap className="h-5 w-5 text-green-500" />
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-2">
+          {strengths.length > 0 ? (
+            strengths.slice(0, 4).map((strength, index) => (
+              <li key={index} className="flex items-start gap-2">
+                <CheckCircle2 className="h-4 w-4 text-green-500 mt-0.5 shrink-0" />
+                <span className="text-sm">{strength}</span>
+              </li>
+            ))
+          ) : (
+            <li className="text-sm text-muted-foreground">
+              Play more matches to discover your strengths
+            </li>
+          )}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ============================================================================
+// Weaknesses Card
+// ============================================================================
+
+function WeaknessesCard({ weaknesses }: { weaknesses: string[] }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardDescription>Focus areas</CardDescription>
+        <CardTitle className="flex items-center justify-between">
+          <span>To Improve</span>
+          <AlertTriangle className="h-5 w-5 text-amber-500" />
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-2">
+          {weaknesses.length > 0 ? (
+            weaknesses.slice(0, 4).map((weakness, index) => (
+              <li key={index} className="flex items-start gap-2">
+                <Target className="h-4 w-4 text-amber-500 mt-0.5 shrink-0" />
+                <span className="text-sm">{weakness}</span>
+              </li>
+            ))
+          ) : (
+            <li className="text-sm text-muted-foreground">
+              No specific weaknesses identified yet
+            </li>
+          )}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ============================================================================
+// Next Step Card
+// ============================================================================
+
+function NextStepCard({
+  nextStep,
+}: {
+  nextStep: PlayerDashboardData["nextStep"];
+}) {
+  return (
+    <Card className="col-span-full bg-gradient-to-br from-primary/5 to-primary/10 border-primary/20">
+      <CardHeader className="pb-2">
+        <CardDescription>Recommended action</CardDescription>
+        <CardTitle>{nextStep.title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground mb-4">
+          {nextStep.description}
+        </p>
+        <Button asChild className="gap-2">
+          <a href={nextStep.actionUrl}>
+            Get started
+            <ArrowRight className="h-4 w-4" />
+          </a>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+export function PlayerDashboard({ data, className }: PlayerDashboardProps) {
+  // Type guard for player dashboard data
+  const playerData = data.data as PlayerDashboardData;
+
+  return (
+    <div className={cn("grid gap-4 md:grid-cols-2 lg:grid-cols-4", className)}>
+      {/* Rating overview - spans 2 columns */}
+      <RatingOverviewCard
+        rating={playerData.rating}
+        recentMatches={playerData.recentMatches}
+      />
+
+      {/* Strengths */}
+      <StrengthsCard strengths={playerData.strengths} />
+
+      {/* Weaknesses */}
+      <WeaknessesCard weaknesses={playerData.weaknesses} />
+
+      {/* Next actionable step - spans full width */}
+      <NextStepCard nextStep={playerData.nextStep} />
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/scout/index.ts
+++ b/apps/web/src/components/dashboard/scout/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Scout Dashboard exports
+ *
+ * @module components/dashboard/scout
+ */
+
+export { ScoutDashboard } from "./scout-dashboard";

--- a/apps/web/src/components/dashboard/scout/scout-dashboard.tsx
+++ b/apps/web/src/components/dashboard/scout/scout-dashboard.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+/**
+ * Scout Dashboard
+ *
+ * Opponent analysis focused dashboard showing:
+ * - Recent opponents with map pools
+ * - Map meta statistics
+ * - Player watchlist
+ *
+ * @module components/dashboard/scout/scout-dashboard
+ */
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { RatingBadge } from "@/components/rating/rating-badge";
+import { type DashboardData, type ScoutDashboardData } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import {
+  Map,
+  Users,
+  Eye,
+  ArrowRight,
+  Trophy,
+  Calendar,
+  Percent,
+  Search,
+  Bookmark,
+  User,
+} from "lucide-react";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface ScoutDashboardProps {
+  data: DashboardData;
+  className?: string;
+}
+
+// ============================================================================
+// Map Icons/Colors
+// ============================================================================
+
+const MAP_COLORS: Record<string, string> = {
+  de_mirage: "bg-amber-500",
+  de_inferno: "bg-orange-500",
+  de_nuke: "bg-blue-500",
+  de_overpass: "bg-green-500",
+  de_ancient: "bg-emerald-500",
+  de_anubis: "bg-yellow-500",
+  de_vertigo: "bg-cyan-500",
+  default: "bg-gray-500",
+};
+
+function MapBadge({ map }: { map: string }) {
+  const mapName = map.replace("de_", "").charAt(0).toUpperCase() + map.replace("de_", "").slice(1);
+  const color = MAP_COLORS[map] || MAP_COLORS.default;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center px-2 py-0.5 rounded text-xs font-medium text-white",
+        color,
+      )}
+    >
+      {mapName}
+    </span>
+  );
+}
+
+// ============================================================================
+// Recent Opponents Card
+// ============================================================================
+
+function RecentOpponentsCard({
+  opponents,
+}: {
+  opponents: ScoutDashboardData["recentOpponents"];
+}) {
+  return (
+    <Card className="col-span-full lg:col-span-2">
+      <CardHeader className="pb-2">
+        <CardDescription>Team Intelligence</CardDescription>
+        <CardTitle className="flex items-center justify-between">
+          <span>Recent Opponents</span>
+          <Button variant="ghost" size="sm" className="gap-1">
+            View all
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {opponents.length > 0 ? (
+          <div className="space-y-4">
+            {opponents.slice(0, 4).map((opponent, index) => (
+              <div
+                key={index}
+                className="flex items-center justify-between p-3 rounded-lg bg-muted/50 hover:bg-muted transition-colors cursor-pointer"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
+                    <Users className="h-5 w-5 text-primary" />
+                  </div>
+                  <div>
+                    <p className="font-medium">{opponent.teamName}</p>
+                    <div className="flex items-center gap-1 mt-1">
+                      {opponent.mapPool.slice(0, 3).map((map) => (
+                        <MapBadge key={map} map={map} />
+                      ))}
+                      {opponent.mapPool.length > 3 && (
+                        <span className="text-xs text-muted-foreground">
+                          +{opponent.mapPool.length - 3}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div className="flex items-center gap-1 text-sm">
+                    <Trophy className="h-4 w-4 text-muted-foreground" />
+                    <span
+                      className={cn(
+                        "font-medium",
+                        opponent.winRate >= 0.5 ? "text-green-500" : "text-red-500",
+                      )}
+                    >
+                      {(opponent.winRate * 100).toFixed(0)}%
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1 text-xs text-muted-foreground mt-1">
+                    <Calendar className="h-3 w-3" />
+                    {new Date(opponent.lastPlayed).toLocaleDateString()}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-8">
+            <Search className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
+            <p className="text-muted-foreground">
+              No recent opponents found. Play more matches to track opponents.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ============================================================================
+// Map Meta Card
+// ============================================================================
+
+function MapMetaCard({ mapMeta }: { mapMeta: ScoutDashboardData["mapMeta"] }) {
+  const maps = Object.entries(mapMeta).sort(
+    ([, a], [, b]) => b.pickRate - a.pickRate,
+  );
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardDescription>Current Meta</CardDescription>
+        <CardTitle className="flex items-center justify-between">
+          <span>Map Pool</span>
+          <Map className="h-5 w-5 text-muted-foreground" />
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {maps.length > 0 ? (
+          <div className="space-y-3">
+            {maps.slice(0, 5).map(([map, stats]) => (
+              <div key={map} className="space-y-1">
+                <div className="flex items-center justify-between text-sm">
+                  <div className="flex items-center gap-2">
+                    <MapBadge map={map} />
+                    <span className="text-muted-foreground">{stats.avgScore}</span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Percent className="h-3 w-3 text-muted-foreground" />
+                    <span className="font-medium">
+                      {(stats.pickRate * 100).toFixed(0)}%
+                    </span>
+                  </div>
+                </div>
+                <Progress value={stats.pickRate * 100} className="h-1.5" />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground text-center py-4">
+            No map data available
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ============================================================================
+// Watchlist Card
+// ============================================================================
+
+function WatchlistCard({
+  watchlist,
+}: {
+  watchlist: ScoutDashboardData["watchlist"];
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardDescription>Players to watch</CardDescription>
+        <CardTitle className="flex items-center justify-between">
+          <span>Watchlist</span>
+          <Eye className="h-5 w-5 text-muted-foreground" />
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {watchlist.length > 0 ? (
+          <div className="space-y-2">
+            {watchlist.slice(0, 5).map((player) => (
+              <div
+                key={player.steamId}
+                className="flex items-center justify-between p-2 rounded hover:bg-muted/50 transition-colors cursor-pointer"
+              >
+                <div className="flex items-center gap-2">
+                  <div className="h-8 w-8 rounded-full bg-muted flex items-center justify-center">
+                    <User className="h-4 w-4 text-muted-foreground" />
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium">{player.name}</p>
+                    <p className="text-xs text-muted-foreground">{player.team}</p>
+                  </div>
+                </div>
+                <RatingBadge rating={player.rating} size="sm" />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-4">
+            <Bookmark className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
+            <p className="text-sm text-muted-foreground">
+              Add players to your watchlist
+            </p>
+            <Button variant="outline" size="sm" className="mt-2">
+              Browse players
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ============================================================================
+// Quick Actions Card
+// ============================================================================
+
+function QuickActionsCard() {
+  return (
+    <Card className="col-span-full bg-gradient-to-br from-primary/5 to-primary/10 border-primary/20">
+      <CardHeader className="pb-2">
+        <CardDescription>Scout Tools</CardDescription>
+        <CardTitle>Quick Actions</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" size="sm" className="gap-2">
+            <Search className="h-4 w-4" />
+            Search Teams
+          </Button>
+          <Button variant="outline" size="sm" className="gap-2">
+            <User className="h-4 w-4" />
+            Find Players
+          </Button>
+          <Button variant="outline" size="sm" className="gap-2">
+            <Map className="h-4 w-4" />
+            Map Analysis
+          </Button>
+          <Button variant="outline" size="sm" className="gap-2">
+            <Eye className="h-4 w-4" />
+            Watch VOD
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+export function ScoutDashboard({ data, className }: ScoutDashboardProps) {
+  // Type guard for scout dashboard data
+  const scoutData = data.data as ScoutDashboardData;
+
+  return (
+    <div className={cn("grid gap-4 md:grid-cols-2 lg:grid-cols-4", className)}>
+      {/* Recent opponents - spans 2 columns */}
+      <RecentOpponentsCard opponents={scoutData.recentOpponents} />
+
+      {/* Map meta */}
+      <MapMetaCard mapMeta={scoutData.mapMeta} />
+
+      {/* Watchlist */}
+      <WatchlistCard watchlist={scoutData.watchlist} />
+
+      {/* Quick actions - spans full width */}
+      <QuickActionsCard />
+    </div>
+  );
+}

--- a/apps/web/src/components/rating/rating-badge.tsx
+++ b/apps/web/src/components/rating/rating-badge.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils";
 
 interface RatingBadgeProps {
   rating: number;
-  size?: "sm" | "md" | "lg";
+  size?: "sm" | "md" | "lg" | "xl";
   showLabel?: boolean;
   className?: string;
 }
@@ -74,6 +74,7 @@ const sizeClasses = {
   sm: "text-xs px-1.5 py-0.5",
   md: "text-sm px-2 py-1",
   lg: "text-base px-3 py-1.5",
+  xl: "text-lg px-4 py-2",
 };
 
 export function RatingBadge({

--- a/apps/web/src/hooks/use-preferences.ts
+++ b/apps/web/src/hooks/use-preferences.ts
@@ -1,0 +1,247 @@
+/**
+ * Hook for managing user preferences with API sync
+ *
+ * Provides:
+ * - Automatic fetching and caching of preferences
+ * - Optimistic updates with API sync
+ * - Role switching with persistence
+ * - Onboarding state management
+ *
+ * @module hooks/use-preferences
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+import {
+  usePreferencesStore,
+  type PreferredRole,
+  type UserPreferences,
+} from "@/stores/preferences-store";
+import { useAuthStore } from "@/stores/auth-store";
+import { userApi, type UpdatePreferencesDto } from "@/lib/api";
+
+// Debounce time for preference updates (ms)
+const SAVE_DEBOUNCE_MS = 1000;
+
+// Sync interval for preferences (5 minutes)
+const SYNC_INTERVAL_MS = 5 * 60 * 1000;
+
+interface UsePreferencesReturn {
+  // Data
+  preferences: UserPreferences | null;
+  preferredRole: PreferredRole;
+
+  // Status
+  isLoading: boolean;
+  isSaving: boolean;
+  error: string | null;
+
+  // Actions
+  fetchPreferences: () => Promise<void>;
+  updatePreferences: (updates: UpdatePreferencesDto) => Promise<void>;
+  setPreferredRole: (role: PreferredRole) => Promise<void>;
+
+  // Onboarding
+  isOnboardingComplete: boolean;
+  onboardingStep: number;
+  completeOnboardingStep: (step: number) => Promise<void>;
+  markWelcomeSeen: () => Promise<void>;
+  markTourCompleted: () => Promise<void>;
+}
+
+export function usePreferences(): UsePreferencesReturn {
+  const { isAuthenticated } = useAuthStore();
+  const store = usePreferencesStore();
+
+  const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const pendingUpdatesRef = useRef<UpdatePreferencesDto>({});
+
+  // Fetch preferences from API
+  const fetchPreferences = useCallback(async () => {
+    if (!isAuthenticated) return;
+
+    store.setLoading(true);
+    store.setError(null);
+
+    try {
+      const prefs = await userApi.getPreferences();
+      store.setPreferences({
+        preferredRole: prefs.preferredRole,
+        dashboardLayout: prefs.dashboardLayout as UserPreferences["dashboardLayout"],
+        favoriteMetrics: prefs.favoriteMetrics,
+        defaultTimeRange: prefs.defaultTimeRange,
+        emailNotifications: prefs.emailNotifications,
+        weeklyDigest: prefs.weeklyDigest,
+        onboardingStep: prefs.onboardingStep,
+        onboardingCompletedAt: prefs.onboardingCompletedAt,
+        hasSeenWelcome: prefs.hasSeenWelcome,
+        hasCompletedTour: prefs.hasCompletedTour,
+        faceitAutoImport: prefs.faceitAutoImport,
+        faceitImportInterval: prefs.faceitImportInterval,
+        theme: prefs.theme as "light" | "dark" | "system",
+        compactMode: prefs.compactMode,
+        showAdvancedStats: prefs.showAdvancedStats,
+        profileVisibility: prefs.profileVisibility,
+        shareStats: prefs.shareStats,
+      });
+      store.markSynced();
+    } catch (error) {
+      store.setError(
+        error instanceof Error ? error.message : "Failed to fetch preferences",
+      );
+    } finally {
+      store.setLoading(false);
+    }
+  }, [isAuthenticated, store]);
+
+  // Debounced save to API
+  const saveToApi = useCallback(async () => {
+    if (Object.keys(pendingUpdatesRef.current).length === 0) return;
+
+    store.setSaving(true);
+
+    try {
+      await userApi.updatePreferences(pendingUpdatesRef.current);
+      pendingUpdatesRef.current = {};
+      store.markSynced();
+    } catch (error) {
+      store.setError(
+        error instanceof Error ? error.message : "Failed to save preferences",
+      );
+    } finally {
+      store.setSaving(false);
+    }
+  }, [store]);
+
+  // Update preferences with debounced API sync
+  const updatePreferences = useCallback(
+    async (updates: UpdatePreferencesDto) => {
+      // Optimistic update in store
+      store.updatePreferences(updates as Partial<UserPreferences>);
+
+      // Accumulate pending updates
+      pendingUpdatesRef.current = {
+        ...pendingUpdatesRef.current,
+        ...updates,
+      };
+
+      // Debounce API call
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+      }
+      saveTimeoutRef.current = setTimeout(saveToApi, SAVE_DEBOUNCE_MS);
+    },
+    [store, saveToApi],
+  );
+
+  // Set preferred role
+  const setPreferredRole = useCallback(
+    async (role: PreferredRole) => {
+      await updatePreferences({ preferredRole: role });
+    },
+    [updatePreferences],
+  );
+
+  // Complete onboarding step
+  const completeOnboardingStep = useCallback(
+    async (step: number) => {
+      store.setOnboardingStep(step);
+      try {
+        await userApi.updateOnboarding(step, false);
+      } catch (error) {
+        store.setError(
+          error instanceof Error ? error.message : "Failed to update onboarding",
+        );
+      }
+    },
+    [store],
+  );
+
+  // Mark welcome as seen
+  const markWelcomeSeen = useCallback(async () => {
+    store.markWelcomeSeen();
+    try {
+      await userApi.markWelcomeSeen();
+    } catch (error) {
+      store.setError(
+        error instanceof Error ? error.message : "Failed to mark welcome seen",
+      );
+    }
+  }, [store]);
+
+  // Mark tour as completed
+  const markTourCompleted = useCallback(async () => {
+    store.markTourCompleted();
+    store.completeOnboarding();
+    try {
+      await userApi.markTourCompleted();
+    } catch (error) {
+      store.setError(
+        error instanceof Error ? error.message : "Failed to mark tour completed",
+      );
+    }
+  }, [store]);
+
+  // Initial fetch on mount (if authenticated)
+  useEffect(() => {
+    if (isAuthenticated && !store.preferences) {
+      fetchPreferences();
+    }
+  }, [isAuthenticated, store.preferences, fetchPreferences]);
+
+  // Periodic sync
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    const interval = setInterval(() => {
+      fetchPreferences();
+    }, SYNC_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [isAuthenticated, fetchPreferences]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+        // Flush pending updates
+        saveToApi();
+      }
+    };
+  }, [saveToApi]);
+
+  return {
+    preferences: store.preferences,
+    preferredRole: store.preferences?.preferredRole ?? "PLAYER",
+    isLoading: store.isLoading,
+    isSaving: store.isSaving,
+    error: store.error,
+    fetchPreferences,
+    updatePreferences,
+    setPreferredRole,
+    isOnboardingComplete: store.preferences?.onboardingCompletedAt !== null,
+    onboardingStep: store.preferences?.onboardingStep ?? 0,
+    completeOnboardingStep,
+    markWelcomeSeen,
+    markTourCompleted,
+  };
+}
+
+/**
+ * Hook for fetching dashboard data
+ */
+export function useDashboard(role?: PreferredRole, timeRange?: string) {
+  const { preferredRole } = usePreferences();
+  const effectiveRole = role ?? preferredRole;
+
+  // Use SWR or React Query pattern in production
+  // For now, simple implementation
+  const fetchDashboard = useCallback(async () => {
+    return userApi.getDashboard(effectiveRole, { timeRange });
+  }, [effectiveRole, timeRange]);
+
+  return {
+    fetchDashboard,
+    role: effectiveRole,
+  };
+}

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -1,0 +1,151 @@
+/**
+ * Authentication state management with Zustand
+ *
+ * Handles user authentication state, tokens, and session management.
+ * Persists auth state to localStorage for session continuity.
+ *
+ * @module stores/auth-store
+ */
+
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  name: string | null;
+  steamId: string | null;
+  faceitId: string | null;
+  avatarUrl: string | null;
+  createdAt: string;
+}
+
+export interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number; // Unix timestamp
+}
+
+interface AuthState {
+  // User data
+  user: AuthUser | null;
+  tokens: AuthTokens | null;
+
+  // Status
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  error: string | null;
+
+  // Actions
+  setUser: (user: AuthUser | null) => void;
+  setTokens: (tokens: AuthTokens | null) => void;
+  setLoading: (isLoading: boolean) => void;
+  setError: (error: string | null) => void;
+
+  // Auth operations
+  login: (user: AuthUser, tokens: AuthTokens) => void;
+  logout: () => void;
+  refreshSession: (tokens: AuthTokens) => void;
+
+  // Computed
+  isTokenExpired: () => boolean;
+  getAccessToken: () => string | null;
+}
+
+// ============================================================================
+// Store Implementation
+// ============================================================================
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set, get) => ({
+      // Initial state
+      user: null,
+      tokens: null,
+      isAuthenticated: false,
+      isLoading: false,
+      error: null,
+
+      // Setters
+      setUser: (user) =>
+        set({
+          user,
+          isAuthenticated: user !== null,
+        }),
+
+      setTokens: (tokens) => set({ tokens }),
+
+      setLoading: (isLoading) => set({ isLoading }),
+
+      setError: (error) => set({ error }),
+
+      // Login - sets both user and tokens
+      login: (user, tokens) =>
+        set({
+          user,
+          tokens,
+          isAuthenticated: true,
+          isLoading: false,
+          error: null,
+        }),
+
+      // Logout - clears everything
+      logout: () =>
+        set({
+          user: null,
+          tokens: null,
+          isAuthenticated: false,
+          isLoading: false,
+          error: null,
+        }),
+
+      // Refresh tokens
+      refreshSession: (tokens) =>
+        set({
+          tokens,
+          error: null,
+        }),
+
+      // Check if token is expired
+      isTokenExpired: () => {
+        const { tokens } = get();
+        if (!tokens) return true;
+
+        // Add 60 second buffer for network latency
+        return Date.now() >= tokens.expiresAt - 60000;
+      },
+
+      // Get access token (returns null if expired)
+      getAccessToken: () => {
+        const state = get();
+        if (!state.tokens || state.isTokenExpired()) {
+          return null;
+        }
+        return state.tokens.accessToken;
+      },
+    }),
+    {
+      name: "cs2-auth-storage",
+      storage: createJSONStorage(() => localStorage),
+      // Only persist user and tokens
+      partialize: (state) => ({
+        user: state.user,
+        tokens: state.tokens,
+        isAuthenticated: state.isAuthenticated,
+      }),
+    },
+  ),
+);
+
+// ============================================================================
+// Selectors (for performance optimization)
+// ============================================================================
+
+export const selectUser = (state: AuthState) => state.user;
+export const selectIsAuthenticated = (state: AuthState) => state.isAuthenticated;
+export const selectIsLoading = (state: AuthState) => state.isLoading;
+export const selectError = (state: AuthState) => state.error;

--- a/apps/web/src/stores/index.ts
+++ b/apps/web/src/stores/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Store exports
+ *
+ * Central export point for all Zustand stores
+ *
+ * @module stores
+ */
+
+export { useDemoStore } from "./demo-store";
+export {
+  useAuthStore,
+  selectUser,
+  selectIsAuthenticated,
+  selectIsLoading as selectAuthIsLoading,
+  selectError as selectAuthError,
+  type AuthUser,
+  type AuthTokens,
+} from "./auth-store";
+export {
+  usePreferencesStore,
+  selectPreferences,
+  selectPreferredRole,
+  selectIsOnboardingComplete,
+  selectOnboardingStep,
+  selectTheme,
+  selectIsLoading as selectPreferencesIsLoading,
+  selectIsSaving,
+  ROLE_METADATA,
+  type PreferredRole,
+  type ProfileVisibility,
+  type UserPreferences,
+  type DashboardLayout,
+  type DashboardWidget,
+} from "./preferences-store";

--- a/apps/web/src/stores/preferences-store.ts
+++ b/apps/web/src/stores/preferences-store.ts
@@ -1,0 +1,332 @@
+/**
+ * User Preferences state management with Zustand
+ *
+ * Manages user preferences including:
+ * - Preferred role (PLAYER, COACH, SCOUT, ANALYST, CREATOR)
+ * - Dashboard customization
+ * - Notification settings
+ * - UI preferences
+ *
+ * @module stores/preferences-store
+ */
+
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type PreferredRole =
+  | "PLAYER"
+  | "COACH"
+  | "SCOUT"
+  | "ANALYST"
+  | "CREATOR";
+
+export type ProfileVisibility = "PUBLIC" | "FRIENDS" | "PRIVATE";
+
+export interface DashboardLayout {
+  widgets: DashboardWidget[];
+  columns?: number;
+}
+
+export interface DashboardWidget {
+  id: string;
+  type: string;
+  position: { x: number; y: number };
+  size: { width: number; height: number };
+  config?: Record<string, unknown>;
+}
+
+export interface UserPreferences {
+  // Role preference
+  preferredRole: PreferredRole;
+
+  // Dashboard customization
+  dashboardLayout: DashboardLayout | null;
+  favoriteMetrics: string[];
+  defaultTimeRange: string;
+
+  // Notifications
+  emailNotifications: boolean;
+  weeklyDigest: boolean;
+
+  // Onboarding state
+  onboardingStep: number;
+  onboardingCompletedAt: string | null;
+  hasSeenWelcome: boolean;
+  hasCompletedTour: boolean;
+
+  // Integration settings
+  faceitAutoImport: boolean;
+  faceitImportInterval: number;
+
+  // UI preferences
+  theme: "light" | "dark" | "system";
+  compactMode: boolean;
+  showAdvancedStats: boolean;
+
+  // Privacy
+  profileVisibility: ProfileVisibility;
+  shareStats: boolean;
+}
+
+interface PreferencesState {
+  // Preferences data
+  preferences: UserPreferences | null;
+
+  // Status
+  isLoading: boolean;
+  isSaving: boolean;
+  error: string | null;
+  lastSyncedAt: number | null;
+
+  // Actions
+  setPreferences: (preferences: UserPreferences | null) => void;
+  updatePreferences: (updates: Partial<UserPreferences>) => void;
+  setLoading: (isLoading: boolean) => void;
+  setSaving: (isSaving: boolean) => void;
+  setError: (error: string | null) => void;
+  markSynced: () => void;
+
+  // Role management
+  setPreferredRole: (role: PreferredRole) => void;
+
+  // Onboarding
+  setOnboardingStep: (step: number) => void;
+  completeOnboarding: () => void;
+  markWelcomeSeen: () => void;
+  markTourCompleted: () => void;
+
+  // UI preferences
+  setTheme: (theme: "light" | "dark" | "system") => void;
+  toggleCompactMode: () => void;
+  toggleAdvancedStats: () => void;
+
+  // Reset
+  reset: () => void;
+}
+
+// ============================================================================
+// Default preferences
+// ============================================================================
+
+const DEFAULT_PREFERENCES: UserPreferences = {
+  preferredRole: "PLAYER",
+  dashboardLayout: null,
+  favoriteMetrics: ["rating", "adr", "kast"],
+  defaultTimeRange: "30d",
+  emailNotifications: true,
+  weeklyDigest: true,
+  onboardingStep: 0,
+  onboardingCompletedAt: null,
+  hasSeenWelcome: false,
+  hasCompletedTour: false,
+  faceitAutoImport: false,
+  faceitImportInterval: 24,
+  theme: "system",
+  compactMode: false,
+  showAdvancedStats: false,
+  profileVisibility: "FRIENDS",
+  shareStats: true,
+};
+
+// ============================================================================
+// Store Implementation
+// ============================================================================
+
+export const usePreferencesStore = create<PreferencesState>()(
+  persist(
+    (set, get) => ({
+      // Initial state
+      preferences: null,
+      isLoading: false,
+      isSaving: false,
+      error: null,
+      lastSyncedAt: null,
+
+      // Setters
+      setPreferences: (preferences) =>
+        set({
+          preferences,
+          error: null,
+        }),
+
+      updatePreferences: (updates) =>
+        set((state) => ({
+          preferences: state.preferences
+            ? { ...state.preferences, ...updates }
+            : { ...DEFAULT_PREFERENCES, ...updates },
+        })),
+
+      setLoading: (isLoading) => set({ isLoading }),
+      setSaving: (isSaving) => set({ isSaving }),
+      setError: (error) => set({ error }),
+      markSynced: () => set({ lastSyncedAt: Date.now() }),
+
+      // Role management
+      setPreferredRole: (role) => {
+        const { preferences } = get();
+        set({
+          preferences: preferences
+            ? { ...preferences, preferredRole: role }
+            : { ...DEFAULT_PREFERENCES, preferredRole: role },
+        });
+      },
+
+      // Onboarding
+      setOnboardingStep: (step) => {
+        const { preferences } = get();
+        set({
+          preferences: preferences
+            ? { ...preferences, onboardingStep: step }
+            : { ...DEFAULT_PREFERENCES, onboardingStep: step },
+        });
+      },
+
+      completeOnboarding: () => {
+        const { preferences } = get();
+        set({
+          preferences: preferences
+            ? {
+                ...preferences,
+                onboardingCompletedAt: new Date().toISOString(),
+              }
+            : {
+                ...DEFAULT_PREFERENCES,
+                onboardingCompletedAt: new Date().toISOString(),
+              },
+        });
+      },
+
+      markWelcomeSeen: () => {
+        const { preferences } = get();
+        set({
+          preferences: preferences
+            ? { ...preferences, hasSeenWelcome: true }
+            : { ...DEFAULT_PREFERENCES, hasSeenWelcome: true },
+        });
+      },
+
+      markTourCompleted: () => {
+        const { preferences } = get();
+        set({
+          preferences: preferences
+            ? { ...preferences, hasCompletedTour: true }
+            : { ...DEFAULT_PREFERENCES, hasCompletedTour: true },
+        });
+      },
+
+      // UI preferences
+      setTheme: (theme) => {
+        const { preferences } = get();
+        set({
+          preferences: preferences
+            ? { ...preferences, theme }
+            : { ...DEFAULT_PREFERENCES, theme },
+        });
+      },
+
+      toggleCompactMode: () => {
+        const { preferences } = get();
+        const current = preferences?.compactMode ?? false;
+        set({
+          preferences: preferences
+            ? { ...preferences, compactMode: !current }
+            : { ...DEFAULT_PREFERENCES, compactMode: !current },
+        });
+      },
+
+      toggleAdvancedStats: () => {
+        const { preferences } = get();
+        const current = preferences?.showAdvancedStats ?? false;
+        set({
+          preferences: preferences
+            ? { ...preferences, showAdvancedStats: !current }
+            : { ...DEFAULT_PREFERENCES, showAdvancedStats: !current },
+        });
+      },
+
+      // Reset
+      reset: () =>
+        set({
+          preferences: null,
+          isLoading: false,
+          isSaving: false,
+          error: null,
+          lastSyncedAt: null,
+        }),
+    }),
+    {
+      name: "cs2-preferences-storage",
+      storage: createJSONStorage(() => localStorage),
+      // Only persist preferences and lastSyncedAt
+      partialize: (state) => ({
+        preferences: state.preferences,
+        lastSyncedAt: state.lastSyncedAt,
+      }),
+    },
+  ),
+);
+
+// ============================================================================
+// Selectors (for performance optimization)
+// ============================================================================
+
+export const selectPreferences = (state: PreferencesState) => state.preferences;
+export const selectPreferredRole = (state: PreferencesState) =>
+  state.preferences?.preferredRole ?? "PLAYER";
+export const selectIsOnboardingComplete = (state: PreferencesState) =>
+  state.preferences?.onboardingCompletedAt !== null;
+export const selectOnboardingStep = (state: PreferencesState) =>
+  state.preferences?.onboardingStep ?? 0;
+export const selectTheme = (state: PreferencesState) =>
+  state.preferences?.theme ?? "system";
+export const selectIsLoading = (state: PreferencesState) => state.isLoading;
+export const selectIsSaving = (state: PreferencesState) => state.isSaving;
+
+// ============================================================================
+// Role metadata
+// ============================================================================
+
+export const ROLE_METADATA: Record<
+  PreferredRole,
+  {
+    label: string;
+    description: string;
+    icon: string;
+    focusAreas: string[];
+  }
+> = {
+  PLAYER: {
+    label: "Player",
+    description: "Focus on personal improvement and individual performance",
+    icon: "User",
+    focusAreas: ["Rating", "ADR", "KAST", "Impact", "Consistency"],
+  },
+  COACH: {
+    label: "Coach",
+    description: "Team management and player development",
+    icon: "Users",
+    focusAreas: ["Team Health", "Player Progress", "Strategy Execution"],
+  },
+  SCOUT: {
+    label: "Scout",
+    description: "Opponent analysis and meta tracking",
+    icon: "Search",
+    focusAreas: ["Opponent Tendencies", "Map Meta", "Player Profiles"],
+  },
+  ANALYST: {
+    label: "Analyst",
+    description: "Deep statistical analysis and insights",
+    icon: "BarChart",
+    focusAreas: ["Advanced Metrics", "Trends", "Statistical Models"],
+  },
+  CREATOR: {
+    label: "Creator",
+    description: "Content creation and highlight discovery",
+    icon: "Video",
+    focusAreas: ["Highlight Moments", "Replay Export", "Visual Content"],
+  },
+};

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -31,6 +31,7 @@ model User {
   teams         TeamMember[]
   demos         Demo[]
   analyses      Analysis[]
+  preferences   UserPreferences?
 
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
@@ -44,6 +45,61 @@ enum Plan {
   PRO
   TEAM
   ENTERPRISE
+}
+
+// User preferences for dashboard personalization
+model UserPreferences {
+  id                    String        @id @default(cuid())
+  userId                String        @unique
+  user                  User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  // Dashboard persona (#41 Role-Based Dashboard)
+  preferredRole         PreferredRole @default(PLAYER)
+
+  // Dashboard customization
+  dashboardLayout       Json?         // Widget positions and visibility
+  favoriteMetrics       String[]      @default([])
+  defaultTimeRange      String        @default("30d") // 7d, 30d, 90d, all
+
+  // Notification preferences
+  emailNotifications    Boolean       @default(true)
+  weeklyDigest          Boolean       @default(true)
+
+  // Onboarding state (#42)
+  onboardingStep        Int           @default(0)
+  onboardingCompletedAt DateTime?
+  hasSeenWelcome        Boolean       @default(false)
+  hasCompletedTour      Boolean       @default(false)
+
+  // Integration settings
+  faceitAutoImport      Boolean       @default(false)
+  faceitImportInterval  Int           @default(24) // Hours between auto-imports
+
+  // Display preferences
+  theme                 String        @default("system") // light, dark, system
+  compactMode           Boolean       @default(false)
+  showAdvancedStats     Boolean       @default(false)
+
+  // Privacy settings
+  profileVisibility     ProfileVisibility @default(FRIENDS)
+  shareStats            Boolean           @default(true)
+
+  createdAt             DateTime      @default(now())
+  updatedAt             DateTime      @updatedAt
+}
+
+enum PreferredRole {
+  PLAYER    // Personal improvement focus
+  COACH     // Team management focus
+  SCOUT     // Opponent analysis focus
+  ANALYST   // Deep data analysis focus
+  CREATOR   // Content creation focus
+}
+
+enum ProfileVisibility {
+  PUBLIC    // Anyone can see
+  FRIENDS   // Only friends/teammates
+  PRIVATE   // Only self
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Implements role-based personalized dashboards allowing users to choose their primary use case (Player, Coach, Scout, Analyst, Creator) and see relevant metrics tailored to their needs.

### Backend
- **UserPreferences model** with comprehensive settings for role preferences, dashboard customization, onboarding state, notification preferences, and privacy controls
- **User module** (controller, service, DTOs) for preferences CRUD operations
- **Dashboard aggregation service** returning role-specific data with Redis caching
- **7 new API endpoints** for user profile and preferences management

### Frontend
- **State management** with Zustand stores for auth and preferences (with localStorage persistence)
- **DashboardRouter** component for role-based routing
- **DashboardSwitcher** component for quick role switching with dropdown
- **PlayerDashboard** showing rating, strengths, weaknesses, and next actionable step
- **CoachDashboard** showing team health, player tiles, and alerts
- **ScoutDashboard** showing opponents, map meta, and watchlist
- **usePreferences hook** with API sync and debounced updates

## API Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/v1/user/me` | Get current user profile |
| GET | `/v1/user/me/preferences` | Get user preferences |
| PATCH | `/v1/user/me/preferences` | Update user preferences |
| GET | `/v1/user/me/dashboard/:role` | Get role-specific dashboard |
| GET | `/v1/user/me/dashboard` | Get dashboard for preferred role |
| POST | `/v1/user/me/onboarding` | Update onboarding progress |
| POST | `/v1/user/me/welcome-seen` | Mark welcome as seen |
| POST | `/v1/user/me/tour-completed` | Mark tour as completed |

## Roles & Focus Areas

| Role | Focus | Key Metrics |
|------|-------|-------------|
| Player | Personal improvement | Rating, ADR, KAST, Impact |
| Coach | Team management | Team health, player progress, alerts |
| Scout | Opponent analysis | Opponents, map meta, watchlist |
| Analyst | Deep statistics | Advanced metrics, trends |
| Creator | Content creation | Highlights, replay export |

## Test Plan

- [ ] Build passes (`pnpm build`)
- [ ] Prisma schema generates successfully
- [ ] API endpoints return correct data shapes
- [ ] Dashboard switches between roles correctly
- [ ] Preferences persist across page refreshes
- [ ] Role-specific dashboards render appropriate cards

## Related Issues

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)